### PR TITLE
quick fix to the docs for conda install

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -20,9 +20,11 @@ install the packages required for development using::
 
 We do require ``msprime``, so please see the the `installation notes
 <https://msprime.readthedocs.io/en/stable/installation.html>`_ if you
-encounter problems with it. Conda users should be able to install the
+encounter problems with it. Conda users will need to add the `conda-forge`
+channel to their conda environment and then should be able to install the
 development requirements using::
-
+    
+    $ conda config --add channels conda-forge 
     $ conda install --file=requirements/development.txt
 
 ***************


### PR DESCRIPTION
just a quick fix up to the install directions for conda. we needed to specify to the user that they should add the `conda-forge` channel before installing the requirements. I'm also tempted to ask the users to start a new virtual environment in conda for stdpopsim, but perhaps that is overkill. 