### PR TITLE
Fly model

### DIFF
--- a/dmel_example.py
+++ b/dmel_example.py
@@ -1,0 +1,24 @@
+"""
+Example of using the stdpopsim library with msprime.
+"""
+import msprime
+
+
+import stdpopsim
+from stdpopsim import drosophila_melanogaster
+
+chrom = drosophila_melanogaster.genome.chromosomes["chr2L"]
+recomb_map = chrom.recombination_map()
+
+model = drosophila_melanogaster.SheehanSongThreeEpoch()
+model.debug()
+
+samples = [msprime.Sample(population=0, time=0),msprime.Sample(population=0,
+                                                               time=0)]
+
+ts = msprime.simulate(
+    samples=samples,
+    recombination_map=chrom.recombination_map(),
+    mutation_rate=chrom.mean_mutation_rate,
+    **model.asdict())
+print("simulated:", ts.num_trees, ts.num_sites)

--- a/dmel_example.py
+++ b/dmel_example.py
@@ -7,7 +7,7 @@ import msprime
 import stdpopsim
 from stdpopsim import drosophila_melanogaster
 
-chrom = drosophila_melanogaster.genome.chromosomes["chr2L"]
+chrom = drosophila_melanogaster.genome.chromosomes["chrX"]
 recomb_map = chrom.recombination_map()
 
 model = drosophila_melanogaster.SheehanSongThreeEpoch()

--- a/stdpopsim/drosophila_melanogaster.py
+++ b/stdpopsim/drosophila_melanogaster.py
@@ -1,7 +1,6 @@
 """
 Genome, genetic map and demographic model definitions for humans.
 """
-import math
 
 import msprime
 
@@ -20,7 +19,7 @@ import stdpopsim.genetic_maps as genetic_maps
 class Comeron2012_dm6(genetic_maps.GeneticMap):
     """
     Comeron et al. (2012) maps (lifted over to dm6) used in
-    Currently needs a readme as to the lift over, etc. 
+    Currently needs a readme as to the lift over, etc.
     """
     url = (
         "http://sesame.uoregon.edu/~adkern/dmel_recombination_map/"

--- a/stdpopsim/drosophila_melanogaster.py
+++ b/stdpopsim/drosophila_melanogaster.py
@@ -17,21 +17,18 @@ import stdpopsim.genetic_maps as genetic_maps
 ###########################################################
 
 
-class HapmapII_GRCh37(genetic_maps.GeneticMap):
+class Comeron2012_dm6(genetic_maps.GeneticMap):
     """
-    The Phase II HapMap Genetic map (lifted over to GRCh37) used in
-    1000 Genomes. Please see the `README
-    <ftp://ftp-trace.ncbi.nih.gov/1000genomes/ftp/technical/working/20110106_recombination_hotspots/README_hapmapII_GRCh37_map>`_
-    for more details.
+    Comeron et al. (2012) maps (lifted over to dm6) used in
+    Currently needs a readme as to the lift over, etc. 
     """
     url = (
-        "http://ftp-trace.ncbi.nih.gov/1000genomes/ftp/technical/working/"
-        "20110106_recombination_hotspots/"
-        "HapmapII_GRCh37_RecombinationHotspots.tar.gz")
-    file_pattern = "genetic_map_GRCh37_{name}.txt"
+        "http://sesame.uoregon.edu/~adkern/dmel_recombination_map/"
+        "comeron2012_maps.tar.gz")
+    file_pattern = "genetic_map_comeron2012_dm6_{name}.txt"
 
 
-genetic_maps.register_genetic_map(HapmapII_GRCh37())
+genetic_maps.register_genetic_map(Comeron2012_dm6())
 
 ###########################################################
 #
@@ -59,7 +56,7 @@ for line in _chromosome_data.splitlines():
     _chromosomes.append(genomes.Chromosome(
         name=name, length=int(length),
         mean_mutation_rate=8.4e-9,  # WRONG!, underestimate used in S&S
-        mean_recombination_rate=1e-8))  # WRONG!
+        mean_recombination_rate=8.4e-9))  # WRONG, underestimate used in S&S!
 
 
 #: :class:`stdpopsim.Genome` definition for D. melanogaster. Chromosome length data is
@@ -67,7 +64,7 @@ for line in _chromosome_data.splitlines():
 genome = genomes.Genome(
     species="drosophila_melanogaster",
     chromosomes=_chromosomes,
-    default_genetic_map=None)
+    default_genetic_map=Comeron2012_dm6.name)
 
 
 ###########################################################
@@ -116,3 +113,4 @@ class SheehanSongThreeEpoch(models.Model):
             msprime.PopulationParametersChange(
                 time=t_2, initial_size=N_A, population_id=0)
         ]
+        self.migration_matrix = [[0]]

--- a/stdpopsim/drosophila_melanogaster.py
+++ b/stdpopsim/drosophila_melanogaster.py
@@ -1,0 +1,118 @@
+"""
+Genome, genetic map and demographic model definitions for humans.
+"""
+import math
+
+import msprime
+
+import stdpopsim.models as models
+import stdpopsim.genomes as genomes
+import stdpopsim.genetic_maps as genetic_maps
+
+
+###########################################################
+#
+# Genetic maps
+#
+###########################################################
+
+
+class HapmapII_GRCh37(genetic_maps.GeneticMap):
+    """
+    The Phase II HapMap Genetic map (lifted over to GRCh37) used in
+    1000 Genomes. Please see the `README
+    <ftp://ftp-trace.ncbi.nih.gov/1000genomes/ftp/technical/working/20110106_recombination_hotspots/README_hapmapII_GRCh37_map>`_
+    for more details.
+    """
+    url = (
+        "http://ftp-trace.ncbi.nih.gov/1000genomes/ftp/technical/working/"
+        "20110106_recombination_hotspots/"
+        "HapmapII_GRCh37_RecombinationHotspots.tar.gz")
+    file_pattern = "genetic_map_GRCh37_{name}.txt"
+
+
+genetic_maps.register_genetic_map(HapmapII_GRCh37())
+
+###########################################################
+#
+# Genome definition
+#
+###########################################################
+
+# List of chromosomes. Data for length information based on DM6,
+# https://www.ncbi.nlm.nih.gov/genome/?term=drosophila+melanogaster.
+# FIXME: add mean mutation and recombination rate data to this table.
+_chromosome_data = """\
+chrX   23542271
+chr2L   23513712
+chr2R   25286936
+chr3L   28110227
+chr3R   32079331
+chr4   1348131
+chrY   3667352
+chrM   19524
+"""
+
+_chromosomes = []
+for line in _chromosome_data.splitlines():
+    name, length = line.split()[:2]
+    _chromosomes.append(genomes.Chromosome(
+        name=name, length=int(length),
+        mean_mutation_rate=8.4e-9,  # WRONG!, underestimate used in S&S
+        mean_recombination_rate=1e-8))  # WRONG!
+
+
+#: :class:`stdpopsim.Genome` definition for D. melanogaster. Chromosome length data is
+# based on DM6
+genome = genomes.Genome(
+    species="drosophila_melanogaster",
+    chromosomes=_chromosomes,
+    default_genetic_map=None)
+
+
+###########################################################
+#
+# Demographic models
+#
+###########################################################
+
+
+class SheehanSongThreeEpoch(models.Model):
+    """
+    The three epoch model estimated for African samples from Sheehan and Song
+
+    .. todo:: document this model, including the original publications
+        and clear information about what the different population indexes
+        mean.
+
+    """
+
+    def __init__(self):
+
+        # Parameter values from "Simulating Data" section
+        # these are assumptions, not estimates
+        N_ref = 100000
+        t_1_coal = 0.5
+        t_2_coal = 5.0
+        # estimates from the ANN
+        N_R = 544200
+        N_B = 145300
+        N_A = 652700
+        # Times are provided in 4N_ref generations, so we convert into generations.
+        # generation_time = 10 / year
+        t_1 = t_1_coal * 4 * N_ref
+        t_2 = t_2_coal * 4 * N_ref
+        # Population IDs correspond to their indexes in the population
+        # configuration array. Therefore, we have 0=YRI, 1=CEU and 2=CHB
+        # initially.
+        self.population_configurations = [
+            msprime.PopulationConfiguration(initial_size=N_R),
+        ]
+        self.demographic_events = [
+            # Size change at bottleneck (back in time; BIT)
+            msprime.PopulationParametersChange(
+                time=t_1, initial_size=N_B, population_id=0),
+            # Size change at recovery (BIT)
+            msprime.PopulationParametersChange(
+                time=t_2, initial_size=N_A, population_id=0)
+        ]

--- a/tests/test_drosophila_melanogaster.py
+++ b/tests/test_drosophila_melanogaster.py
@@ -1,0 +1,74 @@
+"""
+Tests for the human data definitions.
+"""
+import unittest
+import io
+
+import msprime
+
+from stdpopsim import drosophila_melanogaster
+
+
+class TestGenome(unittest.TestCase):
+    """
+    Tests for the human genome.
+    """
+    def test_basic_attributes(self):
+        genome = homo_sapiens.genome
+        self.assertEqual(genome.species, "drosophila_melanogaster")
+        self.assertEqual(genome.default_genetic_map, "Comeron2012_dm6")
+        self.assertEqual(len(genome.chromosomes), 8)
+
+    def test_str(self):
+        s = str(drosophila_melanogaster.genome)
+        self.assertGreater(len(s), 0)
+        self.assertIsInstance(s, str)
+
+    def test_chromosome_lengths(self):
+        genome = homo_sapiens.genome
+        # Numbers from https://www.ncbi.nlm.nih.gov/grc/human/data
+        # GRCh38.p12
+        self.assertEqual(genome.chromosomes["chr1"].length, 248956422)
+        self.assertEqual(genome.chromosomes["chr2"].length, 242193529)
+        self.assertEqual(genome.chromosomes["chr3"].length, 198295559)
+        self.assertEqual(genome.chromosomes["chr4"].length, 190214555)
+        self.assertEqual(genome.chromosomes["chr5"].length, 181538259)
+        self.assertEqual(genome.chromosomes["chr6"].length, 170805979)
+        self.assertEqual(genome.chromosomes["chr7"].length, 159345973)
+        self.assertEqual(genome.chromosomes["chr8"].length, 145138636)
+        self.assertEqual(genome.chromosomes["chr9"].length, 138394717)
+        self.assertEqual(genome.chromosomes["chr10"].length, 133797422)
+        self.assertEqual(genome.chromosomes["chr11"].length, 135086622)
+        self.assertEqual(genome.chromosomes["chr12"].length, 133275309)
+        self.assertEqual(genome.chromosomes["chr13"].length, 114364328)
+        self.assertEqual(genome.chromosomes["chr14"].length, 107043718)
+        self.assertEqual(genome.chromosomes["chr15"].length, 101991189)
+        self.assertEqual(genome.chromosomes["chr16"].length, 90338345)
+        self.assertEqual(genome.chromosomes["chr17"].length, 83257441)
+        self.assertEqual(genome.chromosomes["chr18"].length, 80373285)
+        self.assertEqual(genome.chromosomes["chr19"].length, 58617616)
+        self.assertEqual(genome.chromosomes["chr20"].length, 64444167)
+        self.assertEqual(genome.chromosomes["chr21"].length, 46709983)
+        self.assertEqual(genome.chromosomes["chr22"].length, 50818468)
+        self.assertEqual(genome.chromosomes["chrX"].length, 156040895)
+        self.assertEqual(genome.chromosomes["chrY"].length, 57227415)
+
+
+class TestGutenkunstOutOfAfrica(unittest.TestCase):
+    """
+    Basic tests for the GutenkunstThreePopOutOfAfrica model.
+    """
+
+    def test_simulation_runs(self):
+        model = homo_sapiens.GutenkunstThreePopOutOfAfrica()
+        ts = msprime.simulate(
+            samples=[msprime.Sample(pop, 0) for pop in range(3)],
+            **model.asdict())
+        self.assertEqual(ts.num_populations, 3)
+
+    def test_debug_runs(self):
+        model = homo_sapiens.GutenkunstThreePopOutOfAfrica()
+        output = io.StringIO()
+        model.debug(output)
+        s = output.getvalue()
+        self.assertGreater(len(s), 0)

--- a/tests/test_drosophila_melanogaster.py
+++ b/tests/test_drosophila_melanogaster.py
@@ -36,6 +36,7 @@ class TestGenome(unittest.TestCase):
         self.assertEqual(genome.chromosomes["chr4"].length, 1348131)
         self.assertEqual(genome.chromosomes["chrY"].length, 3667352)
 
+
 class TestSheehanSongThreeEpoch(unittest.TestCase):
     """
     Basic tests for the SheehanSongThreeEpoch model.

--- a/tests/test_drosophila_melanogaster.py
+++ b/tests/test_drosophila_melanogaster.py
@@ -14,7 +14,7 @@ class TestGenome(unittest.TestCase):
     Tests for the drosophila_melanogaster genome.
     """
     def test_basic_attributes(self):
-        genome = homo_sapiens.genome
+        genome = drosophila_melanogaster.genome
         self.assertEqual(genome.species, "drosophila_melanogaster")
         self.assertEqual(genome.default_genetic_map, "Comeron2012_dm6")
         self.assertEqual(len(genome.chromosomes), 8)
@@ -25,7 +25,7 @@ class TestGenome(unittest.TestCase):
         self.assertIsInstance(s, str)
 
     def test_chromosome_lengths(self):
-        genome = homo_sapiens.genome
+        genome = drosophila_melanogaster.genome
         # Numbers from https://www.ncbi.nlm.nih.gov/grc/human/data
         # DM6
         self.assertEqual(genome.chromosomes["chr2L"].length, 23513712)
@@ -35,8 +35,6 @@ class TestGenome(unittest.TestCase):
         self.assertEqual(genome.chromosomes["chrX"].length, 23542271)
         self.assertEqual(genome.chromosomes["chr4"].length, 1348131)
         self.assertEqual(genome.chromosomes["chrY"].length, 3667352)
-
-
 
 class TestSheehanSongThreeEpoch(unittest.TestCase):
     """

--- a/tests/test_drosophila_melanogaster.py
+++ b/tests/test_drosophila_melanogaster.py
@@ -1,5 +1,5 @@
 """
-Tests for the human data definitions.
+Tests for the drosophila_melanogaster data definitions.
 """
 import unittest
 import io
@@ -11,7 +11,7 @@ from stdpopsim import drosophila_melanogaster
 
 class TestGenome(unittest.TestCase):
     """
-    Tests for the human genome.
+    Tests for the drosophila_melanogaster genome.
     """
     def test_basic_attributes(self):
         genome = homo_sapiens.genome
@@ -27,47 +27,31 @@ class TestGenome(unittest.TestCase):
     def test_chromosome_lengths(self):
         genome = homo_sapiens.genome
         # Numbers from https://www.ncbi.nlm.nih.gov/grc/human/data
-        # GRCh38.p12
-        self.assertEqual(genome.chromosomes["chr1"].length, 248956422)
-        self.assertEqual(genome.chromosomes["chr2"].length, 242193529)
-        self.assertEqual(genome.chromosomes["chr3"].length, 198295559)
-        self.assertEqual(genome.chromosomes["chr4"].length, 190214555)
-        self.assertEqual(genome.chromosomes["chr5"].length, 181538259)
-        self.assertEqual(genome.chromosomes["chr6"].length, 170805979)
-        self.assertEqual(genome.chromosomes["chr7"].length, 159345973)
-        self.assertEqual(genome.chromosomes["chr8"].length, 145138636)
-        self.assertEqual(genome.chromosomes["chr9"].length, 138394717)
-        self.assertEqual(genome.chromosomes["chr10"].length, 133797422)
-        self.assertEqual(genome.chromosomes["chr11"].length, 135086622)
-        self.assertEqual(genome.chromosomes["chr12"].length, 133275309)
-        self.assertEqual(genome.chromosomes["chr13"].length, 114364328)
-        self.assertEqual(genome.chromosomes["chr14"].length, 107043718)
-        self.assertEqual(genome.chromosomes["chr15"].length, 101991189)
-        self.assertEqual(genome.chromosomes["chr16"].length, 90338345)
-        self.assertEqual(genome.chromosomes["chr17"].length, 83257441)
-        self.assertEqual(genome.chromosomes["chr18"].length, 80373285)
-        self.assertEqual(genome.chromosomes["chr19"].length, 58617616)
-        self.assertEqual(genome.chromosomes["chr20"].length, 64444167)
-        self.assertEqual(genome.chromosomes["chr21"].length, 46709983)
-        self.assertEqual(genome.chromosomes["chr22"].length, 50818468)
-        self.assertEqual(genome.chromosomes["chrX"].length, 156040895)
-        self.assertEqual(genome.chromosomes["chrY"].length, 57227415)
+        # DM6
+        self.assertEqual(genome.chromosomes["chr2L"].length, 23513712)
+        self.assertEqual(genome.chromosomes["chr2R"].length, 25286936)
+        self.assertEqual(genome.chromosomes["chr3L"].length, 28110227)
+        self.assertEqual(genome.chromosomes["chr3R"].length, 32079331)
+        self.assertEqual(genome.chromosomes["chrX"].length, 23542271)
+        self.assertEqual(genome.chromosomes["chr4"].length, 1348131)
+        self.assertEqual(genome.chromosomes["chrY"].length, 3667352)
 
 
-class TestGutenkunstOutOfAfrica(unittest.TestCase):
+
+class TestSheehanSongThreeEpoch(unittest.TestCase):
     """
-    Basic tests for the GutenkunstThreePopOutOfAfrica model.
+    Basic tests for the SheehanSongThreeEpoch model.
     """
 
     def test_simulation_runs(self):
-        model = homo_sapiens.GutenkunstThreePopOutOfAfrica()
+        model = drosophila_melanogaster.SheehanSongThreeEpoch()
         ts = msprime.simulate(
-            samples=[msprime.Sample(pop, 0) for pop in range(3)],
+            sample_size=2,
             **model.asdict())
-        self.assertEqual(ts.num_populations, 3)
+        self.assertEqual(ts.num_populations, 1)
 
     def test_debug_runs(self):
-        model = homo_sapiens.GutenkunstThreePopOutOfAfrica()
+        model = drosophila_melanogaster.SheehanSongThreeEpoch()
         output = io.StringIO()
         model.debug(output)
         s = output.getvalue()


### PR DESCRIPTION
okay guys here is a module for _Drosophila melanogaster_. With the help of @jradrion I've packaged up the genetic maps estimated from Comeron et al (2012) to play nice with the `stdpopsim` conventions. I've implemented the demographic model from Sheehan and Song (2016) which is a three epoch model estimated from African _Drosophila melanogaster_ data. I have also implemented the required unit tests following the conventions that @jeromekelleher established for the _Homo sapiens_ module. 

One issue is that the genetic maps are currently sitting on a UO server. They could easily be moved someplace else at a later date, I'm just not sure where might be better. Something to consider anyway. 