### PR TITLE
Interactive notebooks on Binder 

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,20 @@
+# This file contains the Conda environment configuration for running stdpopsim 
+# in a Dockerized image on Binder, accessible through https://mybinder.org/.
+# Binder enables any Jupyter notebooks in the repository to be run interactively and
+# reproducibly in a stable cloud-based environment.
+#
+# Developer Note: New Jupyter notebooks that are added to this repository should confirm
+# that any package dependencies are specified in the list below.
+
+name: stdpopsim-environment
+channels:
+        - conda-forge
+dependencies:
+        - numpy
+        - pandas
+        - msprime
+        - scikit-allel
+        - matplotlib
+        # load the stdpopsim Github repository as a library using pip
+        - pip:
+            - "--editable=git+https://github.com/popgensims/stdpopsim.git#egg=stdpopsim-master"

--- a/index.ipynb
+++ b/index.ipynb
@@ -1,0 +1,124 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# QC, analysis of Gutenkunst three pop out of Africa\n",
+    "Here, we would like to do a sanity check that our models are producing similar results to that found \n",
+    "in Gutenkunst 2009.  https://doi.org/10.1371/journal.pgen.1000695\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import msprime\n",
+    "from stdpopsim import homo_sapiens\n",
+    "import allel\n",
+    "import numpy as np\n",
+    "from matplotlib import pyplot as plt\n",
+    "from matplotlib.colors import LogNorm\n",
+    "from allel.util import asarray_ndim, check_integer_dtype"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ch = \"chr22\"\n",
+    "chrom = homo_sapiens.genome.chromosomes[ch]\n",
+    "model = homo_sapiens.GutenkunstThreePopOutOfAfrica()\n",
+    "\n",
+    "pops = [\"YRI\",\"CEU\",\"CHB\"]\n",
+    "treeSequencePath = \"./HomoSapians3pop_\"+ch+\"_50samplesEach.trees\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The tree sequence for this simulation exists at the path 'treeSequencePath',\n",
+    "there is no need to re-simulate if it still exists.\n",
+    "The simulation only takes about a minute for a single chromosome."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 50 samples each from YRI, CEU and CHB.\n",
+    "samples = [msprime.Sample(population=j, time=0) for j in range(3) for _ in range(50)]\n",
+    "\n",
+    "ts = msprime.simulate(\n",
+    "    samples=samples,\n",
+    "    recombination_map=chrom.recombination_map(),\n",
+    "    mutation_rate=chrom.mean_mutation_rate,\n",
+    "    **model.asdict())\n",
+    "ts.dump(treeSequencePath)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, lets take a look at comparisons to nucleotide diversity within all three populations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ts = msprime.load(treeSequencePath)\n",
+    "gm = ts.genotype_matrix()\n",
+    "\n",
+    "#make a haplotype data struct out of each population gentype matrices\n",
+    "haplotype_arrays = [allel.HaplotypeArray(gm[:,ts.samples(population=i)]) for i in range(3)]\n",
+    "total_haplo = allel.HaplotypeArray(gm)\n",
+    "\n",
+    "#counts all ancestral/derived alleles at each site\n",
+    "allele_counts = [pop.count_alleles() for pop in haplotype_arrays]\n",
+    "total_ac = total_haplo.count_alleles()\n",
+    "\n",
+    "#positions of all SNPs\n",
+    "pos = np.array([s.position for s in ts.sites()],dtype='float32')\n",
+    "\n",
+    "for i,ac in enumerate(allele_counts):\n",
+    "    nd = allel.sequence_diversity(pos=pos,ac=ac)\n",
+    "    print(\"pop %s nucleotide diversity = \" %(pops[i]),nd)\n",
+    "    \n",
+    "td = allel.sequence_diversity(pos=pos,ac=total_ac)\n",
+    "print(\"\\ntotal nucleotide diversity: \",td)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "anaconda",
+   "language": "python",
+   "name": "anaconda"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Thought it would be cool to make this available on [Binder](https://mybinder.org/) so we can use cloud-based Jupyter notebooks for interactive documentation/examples (e.g., [qc/homo_sapiens_qc/homo_sapiens.ipynb](https://github.com/popgensims/stdpopsim/blob/master/qc/homo_sapiens_qc/homo_sapiens.ipynb)). The basic setup just requires an `environment.yml` file in the root of the repository, specifying Conda dependencies.

A working demo from my fork is available at:
https://mybinder.org/v2/gh/carjed/stdpopsim/feature/binder_setup (it takes a few moments to load).