### PR TITLE
CLI for running simulations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,8 @@ jobs:
             python setup.py egg_info
             python setup.py bdist_wheel
             pip install dist/*.tar.gz 
+            python3 -m stdpopsim -V
+            stdpopsim -V
 
       - run:
           name: Build docs

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -8,3 +8,4 @@ sphinx-argparse
 sphinx_rtd_theme
 msprime
 appdirs
+daiquiri

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,11 @@ setup(
     keywords='simulations, recombination map, models',
     packages=['stdpopsim'],
     include_package_data=True,
+    entry_points={
+        'console_scripts': [
+            'stdpopsim=stdpopsim.cli:stdpopsim_main',
+        ]
+    },
     install_requires=["msprime", "appdirs"],
     url='https://github.com/popgensims/stdpopsim',
     project_urls={

--- a/stdpopsim/__main__.py
+++ b/stdpopsim/__main__.py
@@ -1,0 +1,4 @@
+from . import cli
+
+if __name__ == "__main__":
+    cli.stdpopsim_main()

--- a/stdpopsim/citations.py
+++ b/stdpopsim/citations.py
@@ -1,0 +1,29 @@
+"""
+Citation management for stdpopsim. Provides utilities for printing
+citation information associated with different entities derived from the
+literature that are used within a simulation.
+"""
+
+
+class CitableMixin(object):
+    """
+    A simple class that provides class attributes which define citation
+    information about an particular entity that should be acknowledged
+    by citation. This is intendted to be used as a simple mixin class;
+    it does not store or change any state of inheriting objects.
+    """
+
+    doi = None
+    """
+    The DOI for the publication providing the definitive reference.
+    """
+
+    author = None
+    """
+    Short author list.
+    """
+
+    year = None
+    """
+    Year of publication as a 4 digit integer, e.g. 2008.
+    """

--- a/stdpopsim/cli.py
+++ b/stdpopsim/cli.py
@@ -1,0 +1,321 @@
+"""
+The command line interface for stdpopsim. Allows provides standard simulations
+at the command line.
+"""
+import argparse
+import json
+import logging
+import platform
+import sys
+import msprime
+import tskit
+
+import stdpopsim
+from stdpopsim import homo_sapiens
+
+
+logger = logging.getLogger(__name__)
+log_format = '%(asctime)s %(levelname)s %(message)s'
+
+
+def exit(message):
+    """
+    Exit with the specified error message, setting error status.
+    """
+    sys.exit("{}: {}".format(sys.argv[0], message))
+
+
+def setup_logging(args):
+    log_level = "WARN"
+    if args.verbosity > 0:
+        log_level = "INFO"
+    if args.verbosity > 1:
+        log_level = "DEBUG"
+    logging.basicConfig(level=log_level, format=log_format)
+
+
+def get_environment():
+    """
+    Returns a dictionary describing the environment in which stdpopsim
+    is currently running.
+    """
+    env = {
+        "os": {
+            "system": platform.system(),
+            "node": platform.node(),
+            "release": platform.release(),
+            "version": platform.version(),
+            "machine": platform.machine(),
+        },
+        "python": {
+            "implementation": platform.python_implementation(),
+            "version": platform.python_version(),
+        },
+        "libraries": {
+            "msprime": {"version": msprime.__version__},
+            "tskit": {"version": tskit.__version__},
+        }
+    }
+    return env
+
+
+def get_provenance_dict():
+    """
+    Returns a dictionary encoding an execution of stdpopsim conforming to the
+    tskit provenance schema.
+    """
+    document = {
+        "schema_version": "1.0.0",
+        "software": {
+            "name": "stdpopsim",
+            "version": stdpopsim.__version__
+        },
+        "parameters": {
+            "command": sys.argv[0],
+            "args": sys.argv[1:]
+        },
+        "environment": get_environment()
+    }
+    return document
+
+
+def write_output(ts, args):
+    """
+    Adds provenance information to the specified tree sequence (ensuring that the
+    output is reproducible) and write the resulting tree sequence to output.
+    """
+    tables = ts.dump_tables()
+    logger.debug("Updating provenance")
+    provenance = get_provenance_dict()
+    tables.provenances.add_row(json.dumps(provenance))
+    ts = tables.tree_sequence()
+    logger.info(f"Writing to {args.output}")
+    ts.dump(args.output)
+
+
+def write_citations(chromosome, model, args):
+    """
+    Write out citation information so that the user knows what papers to cite
+    for the simulation engine, the model and the mutation/recombination rate
+    information.
+    """
+    if not args.quiet:
+        # TODO say this better
+        print(
+            "If you use this simulation in published work, please cite the following "
+            "papers:")
+        print("******************")
+        print("Simulation engine:")
+        print("******************")
+        print(
+            "\tmsprime: Kelleher et al. 2016: "
+            "https://doi.org/10.1371/journal.pcbi.1004842")
+        print("******************")
+        print("Genetic map:")
+        print("******************")
+        print("\tTODO")
+        # TODO need some way to get a GeneticMap instance from the chromosome. We'll also
+        # want to be able to output mutation map, and perhaps other information too, so
+        # we want to keep some flexibility for this in mind.
+        print("Simulation model:")
+        print(f"\t{model.name}: {model.author} {model.year} {model.doi}")
+
+
+# TODO This setup is quite repetive and we can clearly abstract some of this
+# logic about sampling into the model object. What we want is for the model
+# to contain the names of the populations plus some documtation descriptions
+# from which we automatically generate the CLI and this runner inferface
+# can then be entirely generic.
+
+def run_human_gutenkunst_three_pop_ooa(args):
+    if args.num_yri_samples + args.num_ceu_samples + args.num_chb_samples < 2:
+        exit("Must specify at least 2 samples from YRI, CEU or CHB populations")
+
+    chromosome = homo_sapiens.chromosome_factory(
+            args.chromosome, genetic_map=args.genetic_map,
+            length_multiplier=args.length_multiplier)
+    logger.info(
+        f"Running GutenkunstThreePopOutOfAfrica with YRI={args.num_yri_samples}"
+        f" CEU={args.num_ceu_samples} CHB={args.num_chb_samples}")
+    samples = (
+        [msprime.Sample(population=0, time=0)] * args.num_yri_samples +
+        [msprime.Sample(population=1, time=0)] * args.num_ceu_samples +
+        [msprime.Sample(population=2, time=0)] * args.num_chb_samples)
+    model = homo_sapiens.GutenkunstThreePopOutOfAfrica()
+    ts = msprime.simulate(
+        samples=samples,
+        recombination_map=chromosome.recombination_map,
+        mutation_rate=chromosome.mutation_rate,
+        **model.asdict())
+    write_output(ts, args)
+    write_citations(chromosome, model, args)
+
+
+def run_tennessen_two_pop_ooa(args):
+    if args.num_european_samples + args.num_african_samples < 2:
+        exit("Must specify at least 2 samples")
+
+    chromosome = homo_sapiens.chromosome_factory(
+            args.chromosome, genetic_map=args.genetic_map,
+            length_multiplier=args.length_multiplier)
+    model = homo_sapiens.TennessenTwoPopOutOfAfrica()
+    logger.info(
+        f"Running TennessenTwoPopOutOfAfrica with European={args.num_european_samples}"
+        f" African={args.num_african_samples}")
+    samples = (
+        [msprime.Sample(population=0, time=0)] * args.num_european_samples +
+        [msprime.Sample(population=1, time=0)] * args.num_african_samples)
+    ts = msprime.simulate(
+        samples=samples,
+        recombination_map=chromosome.recombination_map,
+        mutation_rate=chromosome.mutation_rate,
+        **model.asdict())
+    write_output(ts, args)
+    write_citations(chromosome, model, args)
+
+
+def run_browning_america(args):
+    total_samples = (
+        args.num_european_samples + args.num_african_samples
+        + args.num_asian_samples + args.num_american_samples)
+    if total_samples < 2:
+        exit("Must specify at least 2 samples")
+
+    chromosome = homo_sapiens.chromosome_factory(
+            args.chromosome, genetic_map=args.genetic_map,
+            length_multiplier=args.length_multiplier)
+    logger.info(
+        f"Running BrowningAmerica with European={args.num_european_samples} "
+        f"African={args.num_african_samples}, Asian={args.num_asian_samples} "
+        f"African={args.num_american_samples}")
+
+    samples = (
+        [msprime.Sample(population=0, time=0)] * args.num_european_samples +
+        [msprime.Sample(population=1, time=0)] * args.num_african_samples +
+        [msprime.Sample(population=2, time=0)] * args.num_asian_samples +
+        [msprime.Sample(population=3, time=0)] * args.num_american_samples)
+
+    model = homo_sapiens.BrowningAmerica()
+    ts = msprime.simulate(
+        samples=samples,
+        recombination_map=chromosome.recombination_map,
+        mutation_rate=chromosome.mutation_rate,
+        **model.asdict())
+    write_output(ts, args)
+    write_citations(chromosome, model, args)
+
+
+def add_output_argument(parser):
+    parser.add_argument(
+        "output",
+        help="The file to write simulated tree sequence to")
+
+
+def stdpopsim_cli_parser():
+
+    # TODO the CLI defined by this hierarchical and clumsy, but it's the best
+    # I could figure out. It can definitely be improved!
+    top_parser = argparse.ArgumentParser(
+        description="Run simulations defined by stdpopsim from the command line")
+    top_parser.add_argument(
+        "-V", "--version", action='version',
+        version='%(prog)s {}'.format(stdpopsim.__version__))
+    top_parser.add_argument(
+        "-v", "--verbosity", action='count', default=0,
+        help="Increase the verbosity")
+    top_parser.add_argument(
+        "-q", "--quiet", action='store_true',
+        help="Do not write out citation information")
+    subparsers = top_parser.add_subparsers(dest="subcommand")
+    subparsers.required = True
+
+    species_parser = subparsers.add_parser(
+        "homo-sapiens",
+        help="Run simulations of human history.")
+    species_parser.add_argument(
+        "-g", "--genetic-map", default=None,
+        # TODO use the genetic map registry
+        choices=["HapmapII_GRCh37", "Decode_2010_sex_averaged"],
+        help="Specify a particular genetic map. Use a flat map by default.")
+    species_parser.add_argument(
+        "-c", "--chromosome", default="chr22",
+        help="Simulate a specific chromosome")
+    species_parser.add_argument(
+        "-l", "--length-multiplier", default=1, type=float,
+        help="Simulate a chromsome of length l times the named chromosome")
+    subsubparsers = species_parser.add_subparsers(dest="subcommand")
+    subsubparsers.required = True
+
+    parser = subsubparsers.add_parser(
+        "GutenkunstThreePopOutOfAfrica",
+        help="Runs the three population out-of-Africa model")
+    parser.set_defaults(runner=run_human_gutenkunst_three_pop_ooa)
+    add_output_argument(parser)
+    parser.add_argument(
+        "--num-yri-samples", default=0, type=int,
+        help="The number of samples to take from the YRI population")
+    parser.add_argument(
+        "--num-ceu-samples", default=0, type=int,
+        help="The number of samples to take from the CEU population")
+    parser.add_argument(
+        "--num-chb-samples", default=0, type=int,
+        help="The number of samples to take from the CHB population")
+
+    parser = subsubparsers.add_parser(
+        "TennessenTwoPopOutOfAfrica",
+        help="Runs the TennessenTwoPopOutOfAfrica model.")
+    add_output_argument(parser)
+    parser.add_argument(
+        "--num-african-samples", default=0, type=int,
+        help="The number of samples to take from the African population")
+    parser.add_argument(
+        "--num-european-samples", default=0, type=int,
+        help="The number of samples to take from the European population")
+    parser.set_defaults(runner=run_tennessen_two_pop_ooa)
+
+    parser = subsubparsers.add_parser(
+        "BrowningAmerica",
+        help="Runs the BrowningAmerica model.")
+    add_output_argument(parser)
+    parser.add_argument(
+        "--num-african-samples", default=0, type=int,
+        help="The number of samples to take from the African population")
+    parser.add_argument(
+        "--num-european-samples", default=0, type=int,
+        help="The number of samples to take from the European population")
+    parser.add_argument(
+        "--num-asian-samples", default=0, type=int,
+        help="The number of samples to take from the Asian population")
+    parser.add_argument(
+        "--num-american-samples", default=0, type=int,
+        help="The number of samples to take from Admixed American population")
+    parser.set_defaults(runner=run_browning_america)
+
+    # Add stubs for discussion
+    species_parser = subparsers.add_parser(
+        "arabadopsis-thaliana",
+        help="Run simulations of Arabadopsis thaliana.")
+
+    species_parser = subparsers.add_parser(
+        "e-coli",
+        help="Run simulations of E-coli.")
+
+    return top_parser
+
+
+def stdpopsim_main(arg_list=None):
+    parser = stdpopsim_cli_parser()
+    args = parser.parse_args(arg_list)
+    setup_logging(args)
+    if not args.quiet:
+        print("*****************************")
+        print("**        WARNING          **")
+        print("*****************************")
+        print("This inferface is highly experimental and *will* change. ")
+        print("It is provided as a work-in-progress to get some feedback on ")
+        print("how to better structure the interfaces")
+        print("Disable this message with the -q option")
+        print("*****************************")
+        print("**      END WARNING        **")
+        print("*****************************")
+    args.runner(args)

--- a/stdpopsim/genetic_maps.py
+++ b/stdpopsim/genetic_maps.py
@@ -14,6 +14,7 @@ import urllib.request
 import msprime
 
 import stdpopsim
+import stdpopsim.citations as citations
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +79,7 @@ class classproperty(object):
         return self.f(owner)
 
 
-class GeneticMap(object):
+class GeneticMap(citations.CitableMixin):
     """
     Class representing a genetic map for a species. Provides functionality for
     downloading and cacheing recombination maps from a remote URL.

--- a/stdpopsim/homo_sapiens.py
+++ b/stdpopsim/homo_sapiens.py
@@ -2,12 +2,15 @@
 Genome, genetic map and demographic model definitions for humans.
 """
 import math
+import logging
 
 import msprime
 
 import stdpopsim.models as models
 import stdpopsim.genomes as genomes
 import stdpopsim.genetic_maps as genetic_maps
+
+logger = logging.getLogger(__name__)
 
 
 ###########################################################
@@ -32,6 +35,7 @@ class HapmapII_GRCh37(genetic_maps.GeneticMap):
         "20110106_recombination_hotspots/"
         "HapmapII_GRCh37_RecombinationHotspots.tar.gz")
     file_pattern = "genetic_map_GRCh37_{name}.txt"
+    doi = "https://doi.org/10.1038/nature06258"
 
 
 genetic_maps.register_genetic_map(HapmapII_GRCh37())
@@ -52,6 +56,7 @@ class Decode_2010_sex_averaged(genetic_maps.GeneticMap):
         "http://sesame.uoregon.edu/~adkern/stdpopsim/decode/"
         "decode_2010_sex-averaged_map.tar.gz")
     file_pattern = "genetic_map_decode_2010_sex-averaged_{name}.txt"
+    doi = "https://doi.org/10.1038/nature09525"
 
 
 genetic_maps.register_genetic_map(Decode_2010_sex_averaged())
@@ -114,6 +119,41 @@ genome = genomes.Genome(
     chromosomes=_chromosomes,
     default_genetic_map=HapmapII_GRCh37.name)
 
+#
+# Experimental interface used to develop the CLI.
+#
+
+
+class TempChromosome(object):
+    """
+    Temporary class while figuring out the best way to do this.
+    """
+    def __init__(self):
+        self.length = None
+        self.recombination_map = None
+        self.mutation_rate = None
+
+
+def chromosome_factory(name, genetic_map=None, length_multiplier=1):
+    """
+    Temporary function to help figure out the right interface for getting
+    chromosome information.
+    """
+    chrom = genome.chromosomes[name]
+    if genetic_map is None:
+        logging.debug(f"Making flat chromosome {length_multiplier} * {chrom.name}")
+        recomb_map = msprime.RecombinationMap.uniform_map(
+            chrom.length * length_multiplier, chrom.default_recombination_rate)
+    else:
+        if length_multiplier != 1:
+            raise ValueError("Cannot use length multiplier with empirical maps")
+        logging.debug(f"Getting map for {chrom.name} from {genetic_map}")
+        recomb_map = chrom.recombination_map(genetic_map)
+
+    ret = TempChromosome()
+    ret.recombination_map = recomb_map
+    ret.mutation_rate = chrom.default_mutation_rate
+    return ret
 
 ###########################################################
 #
@@ -131,6 +171,9 @@ class GutenkunstThreePopOutOfAfrica(models.Model):
         mean.
 
     """
+    author = "Gutenkunst et al."
+    year = 2009
+    doi = "https://doi.org/10.1371/journal.pgen.1000695"
 
     def __init__(self):
         super().__init__()
@@ -204,6 +247,11 @@ class TennessenTwoPopOutOfAfrica(models.Model):
         mean.
 
     """
+    # NOTE choosing the first publication above the 'the' paper to reference.
+    # Should we allow for multiple references??
+    author = "Tennessen et al."
+    year = "2012"
+    doi = "https://doi.org/10.1126/science.1219240"
 
     def __init__(self):
         super().__init__()
@@ -277,6 +325,10 @@ class BrowningAmerica(models.Model):
     This code was ported over from
     `Supplementary File 1 <https://doi.org/10.1371/journal.pgen.1007385.s005>`_
     """
+    author = "Browning et al."
+    year = "2011"
+    doi = "http://dx.doi.org/10.1371/journal.pgen.1007385"
+
     def __init__(self):
         super().__init__()
         N0 = 7310  # initial population size

--- a/stdpopsim/models.py
+++ b/stdpopsim/models.py
@@ -7,6 +7,8 @@ import inspect
 import msprime
 import numpy as np
 
+import stdpopsim.citations as citations
+
 
 # Defaults taken from np.allclose
 DEFAULT_ATOL = 1e-05
@@ -110,17 +112,25 @@ def verify_demographic_events_equal(
                         key, value1, value2))
 
 
-class Model(object):
+class Model(citations.CitableMixin):
     """
     Class representing a simulation model that can be run in msprime.
 
     .. todo:: Document this class.
     """
+
     def __init__(self):
         self.population_configurations = []
         self.demographic_events = []
         # Defaults to a single population
         self.migration_matrix = [[0]]
+
+    @property
+    def name(self):
+        """
+        The name of this model.
+        """
+        return self.__class__.__name__
 
     def debug(self, out_file=sys.stdout):
         # Use the demography debugger to print out the demographic history

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,213 @@
+"""
+Test cases for the command line interfaces to stdpopsim
+"""
+import unittest
+import tempfile
+import pathlib
+import subprocess
+import json
+import sys
+import io
+from unittest import mock
+
+import tskit
+import msprime
+
+import stdpopsim
+import stdpopsim.cli as cli
+
+
+class TestException(Exception):
+    """
+    Custom exception we can throw for testing.
+    """
+
+
+def capture_output(func, *args, **kwargs):
+    """
+    Runs the specified function and arguments, and returns the
+    tuple (stdout, stderr) as strings.
+    """
+    buffer_class = io.BytesIO
+    if sys.version_info[0] == 3:
+        buffer_class = io.StringIO
+    stdout = sys.stdout
+    sys.stdout = buffer_class()
+    stderr = sys.stderr
+    sys.stderr = buffer_class()
+
+    try:
+        func(*args, **kwargs)
+        stdout_output = sys.stdout.getvalue()
+        stderr_output = sys.stderr.getvalue()
+    finally:
+        sys.stdout.close()
+        sys.stdout = stdout
+        sys.stderr.close()
+        sys.stderr = stderr
+    return stdout_output, stderr_output
+
+
+class TestProvenance(unittest.TestCase):
+    """
+    Test basic provenance properties.
+    """
+    def test_schema_validates(self):
+        d = cli.get_provenance_dict()
+        tskit.validate_provenance(d)
+
+    def test_environment(self):
+        # Basic environment should be the same as tskit.
+        d_stdpopsim = cli.get_provenance_dict()
+        d_tskit = tskit.provenance.get_provenance_dict()
+        self.assertEqual(d_stdpopsim["environment"]["os"], d_tskit["environment"]["os"])
+        self.assertEqual(
+            d_stdpopsim["environment"]["python"], d_tskit["environment"]["python"])
+
+    def test_libraries(self):
+        libs = cli.get_provenance_dict()["environment"]["libraries"]
+        self.assertEqual(libs["tskit"]["version"], tskit.__version__)
+        self.assertEqual(libs["msprime"]["version"], msprime.__version__)
+
+    def test_software(self):
+        software = cli.get_provenance_dict()["software"]
+        self.assertEqual(
+            software, {"name": "stdpopsim", "version": stdpopsim.__version__})
+
+    def test_parameters(self):
+        d = cli.get_provenance_dict()["parameters"]
+        self.assertEqual(d["command"], sys.argv[0])
+        self.assertEqual(d["args"], sys.argv[1:])
+
+
+class TestHomoSapiensArgumentParser(unittest.TestCase):
+    """
+    Tests for the argument parsers.
+    """
+
+    def test_defaults(self):
+        parser = cli.stdpopsim_cli_parser()
+        cmd = "homo-sapiens"
+        model = "GutenkunstThreePopOutOfAfrica"
+        output = "test.trees"
+        args = parser.parse_args([cmd, model, output])
+        self.assertEqual(args.output, output)
+        self.assertEqual(args.num_ceu_samples, 0)
+        self.assertEqual(args.num_chb_samples, 0)
+        self.assertEqual(args.num_yri_samples, 0)
+
+
+class TestEndToEnd(unittest.TestCase):
+    """
+    Checks that simulations we run from the CLI have plausible looking output.
+    """
+    def verify(self, cmd, num_samples):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            filename = pathlib.Path(tmpdir) / "output.trees"
+            full_cmd = cmd + f" {filename}"
+            stdout, stderr = capture_output(cli.stdpopsim_main, full_cmd.split())
+            self.assertEqual(len(stderr), 0)
+            self.assertGreater(len(stdout), 0)
+            # TODO converting to str isn't necessary in tskit 0.1.5. Remove.
+            ts = tskit.load(str(filename))
+        self.assertEqual(ts.num_samples, num_samples)
+
+    def test_tennessen_two_pop_ooa(self):
+        cmd = (
+            "homo-sapiens -c chr22 -l0.1 TennessenTwoPopOutOfAfrica --num-african=2 "
+            "--num-european=3")
+        self.verify(cmd, num_samples=5)
+
+    def test_gutenkunst_three_pop_ooa(self):
+        cmd = "homo-sapiens -c chr1 -l0.01 GutenkunstThreePopOutOfAfrica --num-ceu=10"
+        self.verify(cmd, num_samples=10)
+
+    def test_browning_america(self):
+        cmd = "homo-sapiens -c chr1 -l0.01 BrowningAmerica --num-asian=10"
+        self.verify(cmd, num_samples=10)
+
+
+class TestEndToEndSubprocess(TestEndToEnd):
+    """
+    Run the commands in a subprocess so that we can verify the provenance is
+    stored correctly.
+    """
+    def verify(self, cmd, num_samples):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            filename = pathlib.Path(tmpdir) / "output.trees"
+            full_cmd = "python3 -m stdpopsim -q " + cmd + f" {filename}"
+            subprocess.run(full_cmd, shell=True, check=True)
+            # TODO converting to str isn't necessary in tskit 0.1.5. Remove.
+            ts = tskit.load(str(filename))
+        self.assertEqual(ts.num_samples, num_samples)
+        provenance = json.loads(ts.provenance(ts.num_provenances - 1).record)
+        tskit.validate_provenance(provenance)
+        stored_cmd = provenance["parameters"]["args"]
+        self.assertEqual(stored_cmd[0], "-q")
+        self.assertEqual(stored_cmd[1:-1], cmd.split())
+
+
+class TestSetupLogging(unittest.TestCase):
+    """
+    Tests that setup logging has the desired effect.
+    """
+    basic_cmd = [
+        "homo-sapiens", "GutenkunstThreePopOutOfAfrica", "tmp.trees", "--num-ceu=10"]
+
+    def test_default(self):
+        parser = cli.stdpopsim_cli_parser()
+        args = parser.parse_args(self.basic_cmd)
+        with mock.patch("logging.basicConfig") as mocked_setup:
+            cli.setup_logging(args)
+            mocked_setup.assert_called_once_with(level="WARN", format=cli.log_format)
+
+    def test_verbose(self):
+        parser = cli.stdpopsim_cli_parser()
+        args = parser.parse_args(["-v"] + self.basic_cmd)
+        with mock.patch("logging.basicConfig") as mocked_setup:
+            cli.setup_logging(args)
+            mocked_setup.assert_called_once_with(level="INFO", format=cli.log_format)
+
+    def test_very_verbose(self):
+        parser = cli.stdpopsim_cli_parser()
+        args = parser.parse_args(["-vv"] + self.basic_cmd)
+        with mock.patch("logging.basicConfig") as mocked_setup:
+            cli.setup_logging(args)
+            mocked_setup.assert_called_once_with(level="DEBUG", format=cli.log_format)
+
+
+class TestErrors(unittest.TestCase):
+
+    # Need to mock out setup_logging here or we spew logging to the console
+    # in later tests.
+    @mock.patch("stdpopsim.cli.setup_logging")
+    def run_stdpopsim(self, command, mock_setup_logging):
+        stdout, stderr = capture_output(cli.stdpopsim_main, command)
+        self.assertEqual(stderr, "")
+        self.assertEqual(stdout, "")
+        self.assertTrue(mock_setup_logging.called)
+
+    def test_exit(self):
+        with mock.patch("sys.exit", side_effect=TestException) as mocked_exit:
+            with self.assertRaises(TestException):
+                cli.exit("XXX")
+            mocked_exit.assert_called_once()
+            args = mocked_exit.call_args[0]
+            self.assertEqual(len(args), 1)
+            self.assertTrue(args[0].endswith("XXX"))
+
+    def verify_bad_samples(self, cmd):
+        with mock.patch("stdpopsim.cli.exit", side_effect=TestException) as mocked_exit:
+            with self.assertRaises(TestException):
+                cli.stdpopsim_main(cmd.split())
+            mocked_exit.assert_called_once()
+
+    def test_tennessen_model(self):
+        self.verify_bad_samples("-q homo-sapiens TennessenTwoPopOutOfAfrica tmp.trees")
+
+    def test_gutenkunst_three_pop_ooa(self):
+        self.verify_bad_samples(
+            "-q homo-sapiens GutenkunstThreePopOutOfAfrica tmp.trees")
+
+    def test_browning_america(self):
+        self.verify_bad_samples("-q homo-sapiens BrowningAmerica tmp.trees")

--- a/tests/test_homo_sapiens.py
+++ b/tests/test_homo_sapiens.py
@@ -207,3 +207,23 @@ class TestBrowningAmerica(unittest.TestCase):
     def test_qc_model_equal(self):
         model = homo_sapiens.BrowningAmerica()
         self.assertTrue(model.equals(homo_sapiens_qc.BrowningAmerica()))
+
+
+class TestChromosomeFactory(unittest.TestCase):
+    """
+    Simple tests for the temporary chromosome factory object.
+
+    TODO move these into the appropriate location later.
+    """
+    def test_length_multiplier(self):
+        chrom1 = homo_sapiens.chromosome_factory("chr22")
+        for x in [0.125, 1.0, 2.0]:
+            chrom2 = homo_sapiens.chromosome_factory("chr22", length_multiplier=x)
+            self.assertEqual(
+                chrom1.recombination_map.get_positions()[-1] * x,
+                chrom2.recombination_map.get_positions()[-1])
+
+    def test_length_multiplier_on_empirical_map(self):
+        with self.assertRaises(ValueError):
+            homo_sapiens.chromosome_factory(
+                "chr1", "HapmapII_GRCh37", length_multiplier=2)


### PR DESCRIPTION
@reedacartwright made the point that it would be very helpful for people who have no Python knowledge to be able to run standard simulations. So, I thought it might be a good idea to add a command line interface to stdpopsim which would enable this. Here's a very rough first outline for discussion.

When installed, this would be invoked either via ``stdpopsim`` or ``python3 -m stdpopsim``.

The idea is to use hierarchical subcommands for species/models. So, on the top level we currently have:
```
$ python3 -m stdpopsim --help
usage: __main__.py [-h] [-V] [-v]
                   {homo-sapiens,arabadopsis-thaliana,e-coli} ...

Run simulations defined by stdpopsim from the command line

positional arguments:
  {homo-sapiens,arabadopsis-thaliana,e-coli}
    homo-sapiens        Run simulations of human history.
    arabadopsis-thaliana
                        Run simulations of Arabadopsis thaliana.
    e-coli              Run simulations of E-coli.

optional arguments:
  -h, --help            show this help message and exit
  -V, --version         show program's version number and exit
  -v, --verbosity       Increase the verbosity
```

Then, for homo-sapiens, we have further subcommands that define the model:
```
$ python3 -m stdpopsim homo-sapiens --help
usage: __main__.py homo-sapiens [-h] [-g {HapmapII_GRCh37}] [-c CHROMOSOME]
                                {GutenkunstThreePopOutOfAfrica,TennessenEuropean}
                                ...

positional arguments:
  {GutenkunstThreePopOutOfAfrica,TennessenEuropean}
    GutenkunstThreePopOutOfAfrica
                        Runs the three population out-of-Africa model
    TennessenEuropean   Runs the TennessenEuropean model.

optional arguments:
  -h, --help            show this help message and exit
  -g {HapmapII_GRCh37}, --genetic-map {HapmapII_GRCh37}
                        Specify a particular genetic map. Use a flat map by
                        default.
  -c CHROMOSOME, --chromosome CHROMOSOME
                        Simulate a specific chromosome
```
We've defined two population models here, and also allowed the user to specify a genetic map and chromosome (if they want).

Finally, GutenkunstThreePopOutOfAfrica allows us fill in the parameters of the actual model.
```
$ python3 -m stdpopsim homo-sapiens GutenkunstThreePopOutOfAfrica --help
usage: __main__.py homo-sapiens GutenkunstThreePopOutOfAfrica
       [-h] [--num-yri-samples NUM_YRI_SAMPLES]
       [--num-ceu-samples NUM_CEU_SAMPLES] [--num-chb-samples NUM_CHB_SAMPLES]
       output

positional arguments:
  output                The file to write simulated tree sequence to

optional arguments:
  -h, --help            show this help message and exit
  --num-yri-samples NUM_YRI_SAMPLES
                        The number of samples to take from the YRI population
  --num-ceu-samples NUM_CEU_SAMPLES
                        The number of samples to take from the CEU population
  --num-chb-samples NUM_CHB_SAMPLES
                        The number of samples to take from the CHB population
```

Running this with verbosity turned on then, we might see
```
$ python3 -m stdpopsim -vv homo-sapiens -c chr20 GutenkunstThreePopOutOfAfrica out.trees --num-yri-samples=10

2019-03-26 20:34:13,238 [16329] INFO     stdpopsim.cli: Using flat genetic map
2019-03-26 20:34:13,238 [16329] INFO     stdpopsim.cli: Running GutenkunstThreePopOutOfAfrica with YRI=10 CEU=0 CHB=0
```

This is a rough initial outline, and I think it's fairly clear where it would go from here. It would be a good bit of work, but I think probably worth it.

Any thoughts?