### PR TITLE
Refine all_models to only return from within stdpopsim.

### DIFF
--- a/stdpopsim/models.py
+++ b/stdpopsim/models.py
@@ -2,6 +2,7 @@
 Common infrastructure for specifying demographic models.
 """
 import sys
+import inspect
 
 import msprime
 import numpy as np
@@ -172,6 +173,12 @@ class Model(object):
 
 def all_models():
     """
-    Returns the list of all Model classes that have been defined.
+    Returns the list of all Model classes that are defined within the stdpopsim
+    module.
     """
-    return [cls() for cls in Model.__subclasses__()]
+    ret = []
+    for cls in Model.__subclasses__():
+        mod = inspect.getmodule(cls).__name__
+        if mod.startswith("stdpopsim"):
+            ret.append(cls())
+    return ret

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -226,6 +226,12 @@ class TestDemographicEventsEqual(unittest.TestCase):
                 models.verify_demographic_events_equal([a], [b], 1)
 
 
+class DummyModel(models.Model):
+    """
+    Dummy subclass to make sure we're filtering models correctly.
+    """
+
+
 class TestAllModels(unittest.TestCase):
     """
     Tests that we can get all known simulation models.
@@ -237,12 +243,18 @@ class TestAllModels(unittest.TestCase):
         for model in models.all_models():
             self.assertIsInstance(model, models.Model)
 
+    def test_filtering_outside_classes(self):
+        for model in models.all_models():
+            self.assertNotIsInstance(model, DummyModel)
+
 
 class TestModelsEqual(unittest.TestCase):
     """
     Tests Model object equality comparison.
     """
     def test_known_models(self):
+        # This assumes that every model should be equal to itself and should be
+        # different to every other model.
         known_models = models.all_models()
         n = len(known_models)
         for j in range(n):


### PR DESCRIPTION
Changes definition of all_models so that we only return those defined within stdpopsim. Fixes problem encountered in QC process in #60.