### PR TITLE
added mean_recombination_rate to genome and respective tests

### DIFF
--- a/stdpopsim/genomes.py
+++ b/stdpopsim/genomes.py
@@ -47,6 +47,20 @@ class Genome(object):
             mean_recombination_rate += cont
         return mean_recombination_rate
 
+    @property
+    def mean_mutation_rate(self):
+        """
+        This method return the weighted mean mutation rate
+        across all chomosomes in the genome.
+        :rtype: float
+        """
+        mean_mutation_rate = 0
+        for chrom in self.chromosomes.values():
+            normalized_weight = chrom.length / self.length
+            cont = chrom.default_mutation_rate*normalized_weight
+            mean_mutation_rate += cont
+        return mean_mutation_rate
+
 
 class Chromosome(object):
     """

--- a/tests/test_homo_sapiens.py
+++ b/tests/test_homo_sapiens.py
@@ -84,6 +84,10 @@ class TestGenome(unittest.TestCase):
                 self.assertTrue(np.allclose(default_rr, numpy_rr))
 
     def test_default_recombination_rate(self):
+        """
+        Simply test that the mean recombination rate
+        lies between the max and min values
+        """
         genome = homo_sapiens.genome
         highest_rr = 0
         lowest_rr = 10000
@@ -92,8 +96,24 @@ class TestGenome(unittest.TestCase):
             lowest_rr = min(lowest_rr, rr)
             highest_rr = max(highest_rr, rr)
         mean_genome_rr = genome.mean_recombination_rate
-        self.assertGreater(mean_genome_rr, lowest_rr)
-        self.assertGreater(highest_rr, mean_genome_rr)
+        self.assertGreaterEqual(mean_genome_rr, lowest_rr)
+        self.assertGreaterEqual(highest_rr, mean_genome_rr)
+
+    def test_default_mutation_rate(self):
+        """
+        Simply test that the mean mutation rate
+        lies between the max and min values
+        """
+        genome = homo_sapiens.genome
+        highest_mr = 0
+        lowest_mr = 10000
+        for chrom in genome.chromosomes.values():
+            mr = chrom.default_mutation_rate
+            lowest_mr = min(lowest_mr, mr)
+            highest_mr = max(highest_mr, mr)
+        mean_genome_mr = genome.mean_mutation_rate
+        self.assertGreaterEqual(mean_genome_mr, lowest_mr)
+        self.assertGreaterEqual(highest_mr, mean_genome_mr)
 
     def test_warning_from_no_mapped_chromosome(self):
         """


### PR DESCRIPTION
This is trivial at the moment because we don't have any varying default mutation rates for chromosomes - Still, I think we'll need it at some point and it seems to make sense (It makes my analysis code cleaner because we need genome-wide average for inference). Open to suggestions if anyone thinks otherwise. 

@jeromekelleher, @andrewkern thoughts/review?