### PR TITLE
Sheehan song qc

### DIFF
--- a/qc/__init__.py
+++ b/qc/__init__.py
@@ -2,4 +2,4 @@
 
 # Species definitions.
 from . import homo_sapiens_qc  # NOQA
-
+from . import drosophlia_melanogaster_qc # NOQA

--- a/qc/drosophlia_melanogaster_qc.py
+++ b/qc/drosophlia_melanogaster_qc.py
@@ -50,3 +50,41 @@ class LiStephanTwoPopulation(models.Model):
                 time=T_A0, initial_size=N_A1, population_id=0),
         ]
 
+class SheehanSongThreeEpic(models.Model):
+    def __init__(self):
+        super().__init__()
+        # Model from paper https://doi.org/10.1371/journal.pcbi.1004845
+        generation_time = 0.1 ## 10  generations per year
+
+        # Parameters are taken from table 7 using the average stat prediction values
+        # as those were generally stated to be the best
+        N_1 = 544.2e3 # recent
+        N_2 = 145.3e3 # bottleneck
+        N_3 = 652.7e3 # ancestral
+		
+	    # Times taken from simulating data section based on PSMC and converted to
+	    # number of generations from coalescent units using the baseline effective
+        # population size. Note that the coalescent values are calculated by 
+        N_ref = 1e5
+        t_1_coal = 0.5
+        t_2_coal = 5
+        T_1 = t_1_coal * 4 * N_ref
+        T_2 = (t_1_coal + t_2_coal) * 4 * N_ref
+
+        # Set population sizes at T=0
+        self.population_configurations = [
+            msprime.PopulationConfiguration(initial_size=N_1, growth_rate=0),
+        ]
+
+        # Migration matrix, all migrations to admixed population are 0
+        self.migration_matrix = [[0]]
+
+        # Now we add the demographic events working backwards in time. 
+        self.demographic_events = [
+            # Bottleneck
+            msprime.PopulationParametersChange(
+                time=T_1, initial_size=N_2, population_id=0),
+            # Ancestral population size
+            msprime.PopulationParametersChange(
+                time=T_2, initial_size=N_3, population_id=0),
+        ]

--- a/tests/test_drosophila_melanogaster.py
+++ b/tests/test_drosophila_melanogaster.py
@@ -58,6 +58,11 @@ class TestSheehanSongThreeEpoch(unittest.TestCase):
         s = output.getvalue()
         self.assertGreater(len(s), 0)
 
+    def test_qc_model_equal(self):
+        model = drosophila_melanogaster.SheehanSongThreeEpoch()
+        model_qc = drosophlia_melanogaster_qc.SheehanSongThreeEpic()
+        self.assertTrue(model.equals(model_qc))
+
 
 class TestLiStephanTwoPopulation(unittest.TestCase):
     """


### PR DESCRIPTION
Added QC model for Sheehan-Song. There is a difference with the production model based on t2 which will need to be resolved, probably by making `` (t_1_coal + t_2_coal) * 4 * N_ref``. Note also that there is a discrepancy in the number of generations for the epoch times estimated from ``PSMC`` (which uses 2N) and ``msms`` (which uses 4N) in the paper itself. We went with the generation counts based on the 4N coalescence unit since that is what the deep learning model was actually fit on. 
