### PR TITLE
Add SchiffelsZigzag demographic model

### DIFF
--- a/stdpopsim/homo_sapiens.py
+++ b/stdpopsim/homo_sapiens.py
@@ -704,15 +704,9 @@ class SchiffelsZigzag(models.Model):
         SchiffelsZigzag
 
     Model Description:
-        A validation model used by Schiffels and Durbin (2014) and Terhorst and Terhorst, Kamm, and Song (2017) with periods
+        A validation model used by Schiffels and Durbin (2014) and
+        Terhorst and Terhorst, Kamm, and Song (2017) with periods
         of exponential growth and decline in a single population.
-        The original SCRM command for this model was:
-
-        .. code_block::
-
-            scrm 8 1 -N0 14312 -t 1431200 -r 400736 2000000000
-            -eN 0 1 -eG 0.000582262 1318.18 -eG 0.00232905 -329.546 -eG 0.00931619 82.3865
-            -eG 0.0372648 -20.5966 -eG 0.149059 5.14916 -eN 0.596236 0.1 -seed 1 -T -L -p 10 -l 300000.
 
     Model population indexes:
         - Single population: 0
@@ -721,49 +715,42 @@ class SchiffelsZigzag(models.Model):
         python -m stdpopsim homo-sapiens SchiffelsZigzag -h
 
     Citation:
-       Schiffels, S., & Durbin, R. (2014). Inferring human population size and separation history from multiple genome sequences. Nature Genetics. https://doi.org/10.1038/ng.3015
-    """  # noqa: E501
+       Schiffels, S., & Durbin, R. (2014). Inferring human population size and
+       separation history from multiple genome sequences. Nature Genetics.
+       https://doi.org/10.1038/ng.3015
+    """
     author = "Schiffels and Durbin"
     year = 2014
     doi = "https://doi.org/10.1038/ng.3015"
-
-    def ms2msp_nt(self, n0, s, a, N0=14312):
-        """
-        Convert the ms growth rates to those more appropriate for
-        msprime and calculate n(t) according to them.
-        The 4N0 correction is relative to the absolute N0, rather
-        than the epoch specific one. """
-        return n0 * math.exp(-s*a)
 
     def __init__(self):
         super().__init__()
 
         self.generation_time = 29
         N0 = 14312
-        scale = 4 * N0
 
-        g_1 = 1318.18 / scale
-        t_1 = 0.000582262 * scale  # (generations)
+        g_1 = 0.023025
+        t_1 = 33.333
         n_1 = N0
 
-        g_2 = -329.546 / scale
-        t_2 = 0.00232905 * scale
-        n_2 = self.ms2msp_nt(n_1, t_2 - t_1, g_1)
+        g_2 = -0.005756
+        t_2 = 133.33
+        n_2 = N0/10
 
-        g_3 = 82.3865 / scale
-        t_3 = 0.00931619 * scale
-        n_3 = self.ms2msp_nt(n_2, t_3 - t_2, g_2)
+        g_3 = 0.0014391
+        t_3 = 533.33
+        n_3 = N0
 
-        g_4 = -20.5966 / scale
-        t_4 = 0.0372648 * scale
-        n_4 = self.ms2msp_nt(n_3, t_4 - t_3, g_3)
+        g_4 = -0.00035977
+        t_4 = 2133.33
+        n_4 = N0/10
 
-        g_5 = 5.14916 / scale
-        t_5 = 0.149059 * scale
-        n_5 = self.ms2msp_nt(n_4, t_5 - t_4, g_4)
+        g_5 = 8.99448e-5
+        t_5 = 8533.33
+        n_5 = N0
 
-        n_ancient = 0.1 * N0
-        t_ancient = 0.596236 * scale
+        n_ancient = N0/10
+        t_ancient = 34133.31
 
         self.population_configurations = [
             msprime.PopulationConfiguration(

--- a/stdpopsim/homo_sapiens.py
+++ b/stdpopsim/homo_sapiens.py
@@ -733,7 +733,7 @@ class SchiffelsZigzag(models.Model):
         msprime and calculate n(t) according to them.
         The 4N0 correction is relative to the absolute N0, rather
         than the epoch specific one. """
-        return n0 * math.exp(-(s / (4 * N0))*a)
+        return n0 * math.exp(-s*a)
 
     def __init__(self):
         super().__init__()

--- a/tests/test_homo_sapiens.py
+++ b/tests/test_homo_sapiens.py
@@ -278,6 +278,26 @@ class TestRagsdaleArchaic(unittest.TestCase):
         self.assertTrue(model.equals(homo_sapiens_qc.RagsdaleArchaic()))
 
 
+class TestSchiffelsZigzag(unittest.TestCase):
+    """
+    Basic tests for the TestSchiffelsZigzag model.
+    """
+
+    def test_simulation_runs(self):
+        model = homo_sapiens.SchiffelsZigzag()
+        ts = msprime.simulate(
+            samples=[msprime.Sample(0, 0), msprime.Sample(0, 0)],
+            **model.asdict())
+        self.assertEqual(ts.num_populations, 1)
+
+    def test_debug_runs(self):
+        model = homo_sapiens.SchiffelsZigzag()
+        output = io.StringIO()
+        model.debug(output)
+        s = output.getvalue()
+        self.assertGreater(len(s), 0)
+
+
 class TestChromosomeFactory(unittest.TestCase):
     """
     Simple tests for the temporary chromosome factory object.


### PR DESCRIPTION
I've included a basic model that is often used to test demographic inference software (used in the MSMC paper and others), essentially converting an `ms` command to an `msprime` model. Here is the model run through the analysis pipeline with msmc (and with the `steps` modified for plotting to show the full behaviour):

![image](https://user-images.githubusercontent.com/8516981/61742384-fc210980-ad60-11e9-99b1-4cd2609df3e9.png)

I've used a different `N0` from figure 10 of Schiffel's supplementary material but otherwise the model is unchanged. 

The `ms2msp_nt` is a convenience function for calculating the new `n_t` after a given number of generations given a growth rate and `N0`. 

I'm not sure if this will be stupendously useful to others, but I thought I would include it just in case anyone else wants to benchmark against it. 