### PR TITLE
first commit for generic_models bundle

### DIFF
--- a/generic_example.py
+++ b/generic_example.py
@@ -1,0 +1,65 @@
+"""
+Example of using the stdpopsim library with msprime.
+"""
+import msprime
+import stdpopsim
+from stdpopsim import homo_sapiens
+
+chrom = homo_sapiens.genome.chromosomes["chr22"]
+recomb_map = chrom.recombination_map()
+
+
+model = homo_sapiens.GenericConstantSize()
+print("Human constant size debug")
+model.debug()
+
+# three samples
+samples = [
+    msprime.Sample(population=0, time=0),
+    msprime.Sample(population=0, time=0),
+    msprime.Sample(population=0, time=0)]
+
+ts = msprime.simulate(
+    samples=samples,
+    recombination_map=chrom.recombination_map(),
+    mutation_rate=chrom.default_mutation_rate,
+    **model.asdict())
+print("human generic simulated:", ts.num_trees, ts.num_sites)
+# GenericTwoEpoch
+model = stdpopsim.homo_sapiens.GenericTwoEpoch()
+print("Human two epoch debug")
+model.debug()
+
+# two samples
+samples = [
+    msprime.Sample(population=0, time=0),
+    msprime.Sample(population=0, time=0)]
+
+ts = msprime.simulate(
+    samples=samples,
+    recombination_map=chrom.recombination_map(),
+    mutation_rate=chrom.default_mutation_rate,
+    **model.asdict())
+print("Human GenericTwoEpoch simulated:", ts.num_trees, ts.num_sites)
+
+# do generic thing with drosophila
+# chrom = stdpopsim.drosophila_melanogaster.genome.chromosomes["chr2L"]
+# recomb_map = chrom.recombination_map()
+
+# N = 100
+# model = stdpopsim.drosophila_melanogaster.generics.GenericConstantSize(N)
+# print("Drosophila constant size debug")
+# model.debug()
+
+# two samples
+# samples = [
+    # msprime.Sample(population=0, time=0),
+    # msprime.Sample(population=0, time=0)]
+
+# ts = msprime.simulate(
+    # samples=samples,
+    # recombination_map=chrom.recombination_map(),
+    # mutation_rate=chrom.default_mutation_rate,
+    # **model.asdict())
+# print("drosophila generic simulated:", ts.num_trees, ts.num_sites)
+

--- a/stdpopsim/__init__.py
+++ b/stdpopsim/__init__.py
@@ -14,7 +14,7 @@ from . cache import *  # NOQA
 from . genetic_maps import *  # NOQA
 from . models import *  # NOQA
 from . genomes import *  # NOQA
-
+from . import generic_models # NOQA
 # Species definitions.
 from . import homo_sapiens  # NOQA
 from . import pongo  # NOQA

--- a/stdpopsim/arabidopsis_thaliana.py
+++ b/stdpopsim/arabidopsis_thaliana.py
@@ -7,7 +7,7 @@ import numpy as np
 import stdpopsim.models as models
 import stdpopsim.genomes as genomes
 import stdpopsim.genetic_maps as genetic_maps
-
+import stdpopsim.generic_models as generics # NOQA
 
 ###########################################################
 #

--- a/stdpopsim/drosophila_melanogaster.py
+++ b/stdpopsim/drosophila_melanogaster.py
@@ -7,7 +7,7 @@ import msprime
 import stdpopsim.models as models
 import stdpopsim.genomes as genomes
 import stdpopsim.genetic_maps as genetic_maps
-
+import stdpopsim.generic_models as generics # NOQA
 
 ###########################################################
 #
@@ -129,8 +129,8 @@ class SheehanSongThreeEpoch(models.Model):
 
         # Population metadata
         metadata_afr = {
-            "name": "AFR_dmel",
-            "description": "African D. melanogaster population"
+           "name": "AFR_dmel",
+           "description": "African D. melanogaster population"
         }
 
         # Single population in this model

--- a/stdpopsim/e_coli.py
+++ b/stdpopsim/e_coli.py
@@ -5,7 +5,7 @@ import msprime
 
 import stdpopsim.models as models
 import stdpopsim.genomes as genomes
-
+import stdpopsim.generic_models as generics # NOQA
 
 ###########################################################
 #

--- a/stdpopsim/generic_models.py
+++ b/stdpopsim/generic_models.py
@@ -1,0 +1,62 @@
+# generic_models
+import msprime
+
+
+#########
+# Generic Model Mixin class
+# provides generic models that can be
+# initialized with methods
+#
+#
+########
+
+
+class ConstantSizeMixin(object):
+    def __init__(self, N):
+        """
+        Model Name:
+            ConstantSizeMixin
+
+        Model Description:
+            Generic model of constant size. Uses default_population_size
+            depending on organism
+
+        Model population indexes:
+            - Population 0: 0
+
+        CLI help:
+            python -m stdpopsim homo-sapiens GenericConstantSize -h
+        """  # noqa: E501
+        self.population_configurations = [
+            msprime.PopulationConfiguration(initial_size=N)
+        ]
+        self.migration_matrix = [[0]]
+        self.demographic_events = []
+
+
+class TwoEpochMixin(object):
+    def __init__(self, N1, N2, t):
+        """
+        Model Name:
+            TwoEpochMixin
+
+        Model Description:
+            Generic model of a single population with
+            piecewise constant population size with a single change.
+            Defaults depend on organism, but population sizes and time
+            should be set by user
+
+        Model population indexes:
+            - Population 0: 0
+
+        CLI help:
+            python -m stdpopsim homo-sapiens GenericTwoEpoch -h
+        """  # noqa: E501
+        self.population_configurations = [
+            msprime.PopulationConfiguration(initial_size=N1)
+        ]
+        self.migration_matrix = [[0]]
+        self.demographic_events = [
+            msprime.PopulationParametersChange(
+                time=t, initial_size=N2, growth_rate=0, population_id=0),
+        ]

--- a/stdpopsim/homo_sapiens.py
+++ b/stdpopsim/homo_sapiens.py
@@ -9,7 +9,7 @@ import msprime
 import stdpopsim.models as models
 import stdpopsim.genomes as genomes
 import stdpopsim.genetic_maps as genetic_maps
-
+import stdpopsim.generic_models as generic_models
 logger = logging.getLogger(__name__)
 
 
@@ -119,6 +119,7 @@ genome = genomes.Genome(
     chromosomes=_chromosomes,
     default_genetic_map=HapmapII_GRCh37.name)
 
+
 #
 # Experimental interface used to develop the CLI.
 #
@@ -166,7 +167,34 @@ def chromosome_factory(name, genetic_map=None, length_multiplier=1):
 default_generation_time = 25
 
 
-class GutenkunstThreePopOutOfAfrica(models.Model):
+class HomoSapiensModel(models.Model):
+    """
+    TODO: documentation
+    """
+    def __init__(self):
+        super().__init__()
+        self.generation_time = default_generation_time
+        self.default_population_size = 10000
+
+
+class GenericConstantSize(HomoSapiensModel, generic_models.ConstantSizeMixin):
+    def __init__(self):
+        HomoSapiensModel.__init__(self)
+        generic_models.ConstantSizeMixin.__init__(self, self.default_population_size)
+
+
+class GenericTwoEpoch(HomoSapiensModel, generic_models.TwoEpochMixin):
+    def __init__(self, n2=None, t=None):
+        HomoSapiensModel.__init__(self)
+        n1 = self.default_population_size
+        if n2 is None:
+            n2 = n1 / 2.0
+        if t is None:
+            t = n1 / 100
+        generic_models.TwoEpochMixin.__init__(self, n1, n2, t)
+
+
+class GutenkunstThreePopOutOfAfrica(HomoSapiensModel):
     """
     Model Name:
         GutenkunstThreePopOutOfAfrica
@@ -212,7 +240,7 @@ class GutenkunstThreePopOutOfAfrica(models.Model):
         N_EU0 = 1000
         N_AS0 = 510
         # Times are provided in years, so we convert into generations.
-        self.generation_time = default_generation_time
+        # self.generation_time = default_generation_time
         T_AF = 220e3 / self.generation_time
         T_B = 140e3 / self.generation_time
         T_EU_AS = 21.2e3 / self.generation_time
@@ -260,7 +288,7 @@ class GutenkunstThreePopOutOfAfrica(models.Model):
         ]
 
 
-class TennessenTwoPopOutOfAfrica(models.Model):
+class TennessenTwoPopOutOfAfrica(HomoSapiensModel):
     """
     Model Name:
         TennessenTwoPopOutOfAfrica
@@ -301,7 +329,6 @@ class TennessenTwoPopOutOfAfrica(models.Model):
     def __init__(self):
         super().__init__()
 
-        self.generation_time = default_generation_time
         T_AF = 148e3 / self.generation_time
         T_OOA = 51e3 / self.generation_time
         T_EU0 = 23e3 / self.generation_time
@@ -359,7 +386,7 @@ class TennessenTwoPopOutOfAfrica(models.Model):
         ]
 
 
-class TennessenOnePopAfrica(models.Model):
+class TennessenOnePopAfrica(HomoSapiensModel):
     """
     Model Name:
         TennessenOnePopAfrica
@@ -396,7 +423,6 @@ class TennessenOnePopAfrica(models.Model):
     def __init__(self):
         super().__init__()
 
-        self.generation_time = default_generation_time
         T_AF = 148e3 / self.generation_time
         T_EG = 5115 / self.generation_time
 
@@ -426,7 +452,7 @@ class TennessenOnePopAfrica(models.Model):
         ]
 
 
-class BrowningAmerica(models.Model):
+class BrowningAmerica(HomoSapiensModel):
     """
     Model Name:
         BrowningAmerica
@@ -541,7 +567,7 @@ class BrowningAmerica(models.Model):
         self.demographic_events = admixture_event + eu_event + ooa_event + init_event
 
 
-class RagsdaleArchaic(models.Model):
+class RagsdaleArchaic(HomoSapiensModel):
     """
     Model Name:
         RagsdaleArchaic
@@ -698,7 +724,7 @@ class RagsdaleArchaic(models.Model):
         ]
 
 
-class SchiffelsZigzag(models.Model):
+class SchiffelsZigzag(HomoSapiensModel):
     """
     Model Name:
         SchiffelsZigzag

--- a/stdpopsim/pongo.py
+++ b/stdpopsim/pongo.py
@@ -6,12 +6,14 @@ import math
 import msprime
 
 import stdpopsim.models as models
+import stdpopsim.generic_models as generics # NOQA
 
 
 # TODO: how do we define the Orangutan genome here? Are they similar enough to
 # humans that we just use humans? What about the different species of pongo?
 
 # TODO: add a default generation time to the species
+
 
 class LockeEtAlPongoIM(models.Model):
     '''

--- a/tests/test_homo_sapiens.py
+++ b/tests/test_homo_sapiens.py
@@ -298,6 +298,53 @@ class TestSchiffelsZigzag(unittest.TestCase):
         self.assertGreater(len(s), 0)
 
 
+class TestGenericConstantSize(unittest.TestCase):
+    """
+    Basic tests for the GenericConstantSize model.
+    """
+
+    def test_simulation_runs(self):
+        model = homo_sapiens.GenericConstantSize()
+        ts = msprime.simulate(
+            samples=[msprime.Sample(0, 0), msprime.Sample(0, 0)],
+            **model.asdict())
+        self.assertEqual(ts.num_populations, 1)
+
+    def test_debug_runs(self):
+        model = homo_sapiens.GenericConstantSize()
+        output = io.StringIO()
+        model.debug(output)
+        s = output.getvalue()
+        self.assertGreater(len(s), 0)
+
+
+class TestGenericTwoEpoch(unittest.TestCase):
+    """
+    Basic tests for the GenericTwoEpoch model.
+    """
+
+    def test_simulation_runs(self):
+        model = homo_sapiens.GenericTwoEpoch()
+        ts = msprime.simulate(
+            samples=[msprime.Sample(0, 0), msprime.Sample(0, 0)],
+            **model.asdict())
+        self.assertEqual(ts.num_populations, 1)
+
+    def test_debug_runs(self):
+        model = homo_sapiens.GenericTwoEpoch()
+        output = io.StringIO()
+        model.debug(output)
+        s = output.getvalue()
+        self.assertGreater(len(s), 0)
+
+    def test_debug_runs_v2(self):
+        model = homo_sapiens.GenericTwoEpoch(100, 4)
+        output = io.StringIO()
+        model.debug(output)
+        s = output.getvalue()
+        self.assertGreater(len(s), 0)
+
+
 class TestChromosomeFactory(unittest.TestCase):
     """
     Simple tests for the temporary chromosome factory object.


### PR DESCRIPTION
did a bit of work pulling together a `generic_models` bundle that will provide a set of simple models for `stdpopsim` that will be accessible for each of the organisms in a way that should not break the current usage paradigms. that is to say that this set of generic models will be accessible for each organism such that a user can say `homo_sapiens.generic_constant_size()` and get the generic model back. see `generic_example.py` for a usage example. 

the way I have done this involves calling `import` on `generic_models.py` in each of the organism specific files. thus these generic models will also be available at the level of `stdpopsim.generic_model`. Hopefully this is a point of convenience rather than confusion?

additionally I think the generic models are ready to go for the CLI. thoughts on this? 