### PR TITLE
Add numpy to RTD requirements.

### DIFF
--- a/requirements/rtd.txt
+++ b/requirements/rtd.txt
@@ -1,3 +1,4 @@
 # Requirements needed when building on readthedocs.
 setuptools_scm
 appdirs
+numpy


### PR DESCRIPTION
Closes #112

Numpy was missing from RTD requirements, causing builds to fail.