### PR TITLE
Update CI to build singlehtml docs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,4 +55,4 @@ jobs:
       - run:
           name: Build docs
           command: |
-            cd docs && make
+            cd docs && make && make singlehtml

--- a/stdpopsim/catalog/arabidopsis_thaliana.py
+++ b/stdpopsim/catalog/arabidopsis_thaliana.py
@@ -66,7 +66,7 @@ _gm = stdpopsim.GeneticMap(
         "Please see this repo for details on how this was done: "
         "https://github.com/LohmuellerLab/arabidopsis_recomb_maps"),
     citations=[stdpopsim.Citation(
-        doi=None,  # FIXME
+        doi="FIXME",
         author="Salome et al.",
         year=2012)]
     )

--- a/stdpopsim/catalog/drosophila_melanogaster.py
+++ b/stdpopsim/catalog/drosophila_melanogaster.py
@@ -71,7 +71,7 @@ _gm = stdpopsim.GeneticMap(
         "Comeron et al. (2012) maps (lifted over to dm6)."),
     citations=[stdpopsim.Citation(
         author="Comeron et al",
-        doi=None,  # FIXME
+        doi="FIXME",  # FIXME
         year=2012)]
     )
 


### PR DESCRIPTION
Builds are currently broken on RTD because the ``make singlehtml`` docs command is failing. This is almost certainly something to do with #120.

Initial commit adds this to CI so at least we see the failure.