### PR TITLE
Add help for genetic maps

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -417,6 +417,14 @@ class TestHelp(unittest.TestCase):
         for species in stdpopsim.all_species():
             self.run_stdpopsim(f"{species} --help-models")
 
+    def test_homsap_genetic_maps_help(self):
+        self.run_stdpopsim("homsap --help-genetic-maps")
+        self.run_stdpopsim("homsap --help-genetic-maps HapmapII_GRCh37")
+
+    def test_all_species_genetic_maps_help(self):
+        for species in stdpopsim.all_species():
+            self.run_stdpopsim(f"{species} --help-genetic-maps")
+
 
 class TestWriteCitations(unittest.TestCase):
     """


### PR DESCRIPTION
Addressing #130 to add `--help-genetic-maps` option. I tried to closely follow the approach for displaying help with models.