### PR TITLE
Add IM model to models

### DIFF
--- a/stdpopsim/models.py
+++ b/stdpopsim/models.py
@@ -235,8 +235,11 @@ class Model(object):
         return ts
 
 
-# Resuable generic population
+# Reusable generic populations
 _pop0 = Population(name="pop0", description="Generic population")
+_pop1 = Population(name="pop1", description="Generic population")
+_popAnc = Population(name="popAnc", description="Generic ancestral population",
+                     allow_samples=False)
 
 
 class PiecewiseConstantSize(Model):
@@ -259,3 +262,42 @@ class PiecewiseConstantSize(Model):
         for t, N in args:
             self.demographic_events.append(msprime.PopulationParametersChange(
                 time=t, initial_size=N, growth_rate=0, population_id=0))
+
+
+class GenericIM(Model):
+    """
+    Takes parameters N0, N1, N2, T, M12, and M21, as list of arguments:
+    (NA, N1, N2, T, M12, M21).
+    Sampling is disallowed in population index 0, as this is the ancestral
+    population.
+    """
+    id = "IM"
+    name = "Isolation with migration"
+    description = """
+        A generic isolation with migration model where a single ancestral
+        population of size NA splits into two populations of constant size N1
+        and N2 time T generations ago, with migration rates M12 and M21 between
+        the split populations.
+        """
+    citations = []
+    populations = [_pop0, _pop1, _popAnc]
+    author = None
+    year = None
+    doi = None
+
+    def __init__(self, NA, N1, N2, T, M12, M21):
+        self.population_configurations = [
+            msprime.PopulationConfiguration(
+                initial_size=N1, metadata=self.populations[0].asdict()),
+            msprime.PopulationConfiguration(
+                initial_size=N2, metadata=self.populations[1].asdict()),
+            msprime.PopulationConfiguration(
+                initial_size=NA, metadata=self.populations[2].asdict())
+        ]
+        self.migration_matrix = [[0, M12, 0], [M21, 0, 0], [0, 0, 0]]
+        self.demographic_events = [
+            msprime.MassMigration(
+                time=T, source=0, destination=2, proportion=1),
+            msprime.MassMigration(
+                time=T, source=1, destination=2, proportion=1)
+        ]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -381,3 +381,29 @@ class TestPiecewiseConstantSize(unittest.TestCase):
         self.assertEqual(event.time, 0.2)
         self.assertEqual(event.initial_size, 100)
         self.assertEqual(event.growth_rate, 0)
+
+
+class TestGenericIM(unittest.TestCase):
+    """
+    Tests for the generic IM model.
+    """
+    def test_pop_configs(self):
+        model = models.GenericIM(100, 200, 300, 50, 0, 0)
+        self.assertEqual(len(model.population_configurations), 3)
+        self.assertEqual(model.population_configurations[0].initial_size, 200)
+        self.assertEqual(model.population_configurations[1].initial_size, 300)
+        self.assertEqual(model.population_configurations[2].initial_size, 100)
+
+    def test_split(self):
+        model = models.GenericIM(100, 200, 300, 50, 0, 0)
+        self.assertEqual(len(model.demographic_events), 2)
+        self.assertEqual(model.demographic_events[0].time, 50)
+        self.assertEqual(model.demographic_events[1].time, 50)
+
+    def test_migration_rates(self):
+        model = models.GenericIM(100, 200, 300, 50, 0.002, 0.003)
+        self.assertEqual(np.shape(model.migration_matrix), (3, 3))
+        self.assertEqual(model.migration_matrix[0][1], 0.002)
+        self.assertEqual(model.migration_matrix[1][0], 0.003)
+        # check these are the only two nonzero entries in the migration matrix
+        self.assertEqual(np.sum(np.array(model.migration_matrix) != 0), 2)


### PR DESCRIPTION
I added a generic IM model (issue #171) to models.py, below the PiecewiseConstantSize model. Possible that this model should live elsewhere? 