### PR TITLE
Added ability to set sample times for populations

### DIFF
--- a/stdpopsim/catalog/arabidopsis_thaliana.py
+++ b/stdpopsim/catalog/arabidopsis_thaliana.py
@@ -137,7 +137,8 @@ class _Durvasula2017MSMC(ArabidopsisThalianaModel):
         self.migration_matrix = [[0]]
 
         self.population_configurations = [
-           msprime.PopulationConfiguration(initial_size=self.sizes[0])
+           msprime.PopulationConfiguration(initial_size=self.sizes[0],
+                                           metadata=self.populations[0].asdict())
         ]
 
 

--- a/stdpopsim/catalog/homo_sapiens.py
+++ b/stdpopsim/catalog/homo_sapiens.py
@@ -426,7 +426,7 @@ class _BrowningAmerica(HomoSapiensModel):
         stdpopsim.Population(name="ASIA", description="Contemporary Asian population"),
         stdpopsim.Population(
             name="ADMIX", description="Ancient admixed population",
-            allow_samples=False),
+            sampling_time=None),
     ]
 
     citations = [
@@ -538,9 +538,9 @@ class _RagsdaleArchaic(HomoSapiensModel):
         _ceu_population,
         _chb_population,
         stdpopsim.Population(
-            "Neanderthal", "Putative Neanderthals", allow_samples=False),
+            "Neanderthal", "Putative Neanderthals", sampling_time=None),
         stdpopsim.Population(
-            "ArchaicAFR", "Putative Archaic Africans", allow_samples=False),
+            "ArchaicAFR", "Putative Archaic Africans", sampling_time=None),
     ]
     citations = [
         stdpopsim.Citation(
@@ -728,7 +728,7 @@ class _SchiffelsZigzag(HomoSapiensModel):
 
         self.population_configurations = [
             msprime.PopulationConfiguration(
-                initial_size=N0)
+                initial_size=N0, metadata=self.populations[0].asdict())
         ]
 
         self.migration_matrix = [
@@ -783,9 +783,6 @@ class _KammAncientEurasia(HomoSapiensModel):
     populations = [
         stdpopsim.Population(name="Mbuti",
                              description="Present-day African Mbuti"),
-        stdpopsim.Population(name="BasalEurasian",
-                             description="Basal Eurasians",
-                             allow_samples=False),
         stdpopsim.Population(name="LBK",
                              description="Early European farmer (EEF)"),
         stdpopsim.Population(name="Sardinian",
@@ -799,7 +796,10 @@ class _KammAncientEurasia(HomoSapiensModel):
         stdpopsim.Population(name="UstIshim",
                              description="early Palaeolithic Ust'-Ishim"),
         stdpopsim.Population(name="Neanderthal",
-                             description="Altai Neanderthal from Siberia")
+                             description="Altai Neanderthal from Siberia"),
+        stdpopsim.Population(name="BasalEurasian",
+                             description="Basal Eurasians",
+                             sampling_time=None),
     ]
     citations = [
         stdpopsim.Citation(
@@ -880,94 +880,96 @@ class _KammAncientEurasia(HomoSapiensModel):
             [0, 0, 0, 0, 0, 0, 0, 0, 0],
             [0, 0, 0, 0, 0, 0, 0, 0, 0]
         ]
-        # Population IDs: Mbuti = 0; Basal Eurasian = 1;
-        # LBK = 2; Sardinian = 3; Loschbour = 4
-        # MA1 = 5; Han = 6; Ust Ishim = 7; Neanderthal = 8
+        # Population IDs: Mbuti = 0; LBK = 1;
+        # Sardinian = 2; Loschbour = 3; MA1 = 4;
+        # Han = 5; Ust Ishim = 6; Neanderthal = 7;
+        # Basal Eurasian = 8;
         self.population_configurations = [
             msprime.PopulationConfiguration(
                 initial_size=N_Mbu, metadata=self.populations[0].asdict()),
             msprime.PopulationConfiguration(
-                initial_size=N_Basal, metadata=self.populations[1].asdict()),
+                initial_size=N_LBK, metadata=self.populations[1].asdict()),
             msprime.PopulationConfiguration(
-                initial_size=N_LBK, metadata=self.populations[2].asdict()),
+                initial_size=N_Sard, metadata=self.populations[2].asdict()),
             msprime.PopulationConfiguration(
-                initial_size=N_Sard, metadata=self.populations[3].asdict()),
+                initial_size=N_Losch, metadata=self.populations[3].asdict()),
             msprime.PopulationConfiguration(
-                initial_size=N_Losch, metadata=self.populations[4].asdict()),
+                initial_size=N_MA1, metadata=self.populations[4].asdict()),
             msprime.PopulationConfiguration(
-                initial_size=N_MA1, metadata=self.populations[5].asdict()),
+                initial_size=N_Han, metadata=self.populations[5].asdict()),
             msprime.PopulationConfiguration(
-                initial_size=N_Han, metadata=self.populations[6].asdict()),
+                initial_size=N_Ust, metadata=self.populations[6].asdict()),
             msprime.PopulationConfiguration(
-                initial_size=N_Ust, metadata=self.populations[7].asdict()),
+                initial_size=N_Nean, metadata=self.populations[7].asdict()),
             msprime.PopulationConfiguration(
-                initial_size=N_Nean, metadata=self.populations[8].asdict())
+                initial_size=N_Basal, metadata=self.populations[8].asdict())
         ]
         self.demographic_events = [
             # Sardinian receives admixture from Loschbour / WHG
             msprime.MassMigration(
-                time=t_GhostWHG_to_Sard, source=3, destination=4,
+                time=t_GhostWHG_to_Sard, source=2, destination=3,
                 proportion=p_GhostWHG_to_Sard),
             # Sardinian merges into LBK / EEF
+            # Now pop 1: Sardinian-LBK ancestral pop
             msprime.MassMigration(
-                time=t_Sard_LBK, source=3, destination=2,
+                time=t_Sard_LBK, source=2, destination=1,
                 proportion=1.0),
             # Sardinian-LBK ancestral pop size change
             msprime.PopulationParametersChange(
                 time=t_Sard_LBK, initial_size=N_Sard_LBK,
-                population_id=2),
+                population_id=1),
             # LBK / EEF receives admixture from Basal Eurasians
             msprime.MassMigration(
-                time=t_Basal_to_EEF, source=2, destination=1,
+                time=t_Basal_to_EEF, source=1, destination=8,
                 proportion=p_Basal_to_EEF),
             # LBK / EEF merges into Loschbour
             msprime.MassMigration(
-                time=t_LBK_Losch, source=2, destination=4,
+                time=t_LBK_Losch, source=1, destination=3,
                 proportion=1.0),
             # MA1 merges into Loschbour
             msprime.MassMigration(
-                time=t_MA1_Losch, source=5, destination=4,
+                time=t_MA1_Losch, source=4, destination=3,
                 proportion=1.0),
             # Han merges into Loschbour
             msprime.MassMigration(
-                time=t_Han_Losch, source=6, destination=4,
+                time=t_Han_Losch, source=5, destination=3,
                 proportion=1.0),
             # Change in population size in Han-Losch ancestral pop
             msprime.PopulationParametersChange(
                 time=t_Han_Losch, initial_size=N_Han_Losch,
-                population_id=4),
+                population_id=3),
             # UstIshim merges into Loschbour
             msprime.MassMigration(
-                time=t_Ust_Losch, source=7, destination=4,
+                time=t_Ust_Losch, source=6, destination=3,
                 proportion=1.0),
             # Loschbour / Non-Africans receive admixture from Neanderthals
             msprime.MassMigration(
-                time=t_Nean_to_Eurasian, source=4, destination=8,
+                time=t_Nean_to_Eurasian, source=3, destination=7,
                 proportion=p_Nean_to_Eurasian),
             # Basal Eurasians merge into Loschbour / Non-Africans
             msprime.MassMigration(
-                time=t_Basal_Losch, source=1, destination=4,
+                time=t_Basal_Losch, source=8, destination=3,
                 proportion=1.0),
             # Mbuti merge into Loschbour / Non-Africans
             msprime.MassMigration(
-                time=t_Mbu_Losch, source=0, destination=4,
+                time=t_Mbu_Losch, source=0, destination=3,
                 proportion=1.0),
             # Change in population size in Mbuti-Losch ancestral pop
             msprime.PopulationParametersChange(
                 time=t_Mbu_Losch, initial_size=N_Mbu_Losch,
-                population_id=4),
+                population_id=3),
             # Neanderthal change population size
             msprime.PopulationParametersChange(
                 time=t_NeaPopSizeChange, initial_size=N_Nean_Losch,
-                population_id=8),
+                population_id=7),
             # Neanderthal merge into Loschbour / modern humans
             msprime.MassMigration(
-                time=t_Nean_Losch, source=8, destination=4,
+                time=t_Nean_Losch, source=7, destination=3,
                 proportion=1.0),
             # Ancestral hominin population size change
             msprime.PopulationParametersChange(
                 time=t_Nean_Losch, initial_size=N_Nean_Losch,
-                population_id=4),
+                population_id=3),
         ]
 
 

--- a/stdpopsim/catalog/pongo.py
+++ b/stdpopsim/catalog/pongo.py
@@ -7,6 +7,7 @@ import msprime
 
 import stdpopsim.models as models
 
+import stdpopsim
 
 # TODO we need to add a Genome here. Should we just take a copy of the human
 # genome?
@@ -16,6 +17,12 @@ class LockeEtAlPongoIM(models.Model):
     '''
     http://doi.org/10.1038/nature09687
     '''
+    populations = [
+        stdpopsim.Population(
+            "Bornean", "Pongo pygmaeus (Bornean) population"),
+        stdpopsim.Population(
+            "Sumatran", " Pongo abelii (Sumatran) population"),
+    ]
 
     def __init__(self):
         super().__init__()
@@ -52,9 +59,12 @@ class LockeEtAlPongoIM(models.Model):
         # Population IDs correspond to their indexes in the population
         # configuration array. Therefore, we have 0=B and 1=S
         # initially.
+
         self.population_configurations = [
-            msprime.PopulationConfiguration(initial_size=N_B, growth_rate=r_B),
-            msprime.PopulationConfiguration(initial_size=N_S, growth_rate=r_S),
+            msprime.PopulationConfiguration(initial_size=N_B, growth_rate=r_B,
+                                            metadata=self.populations[0].asdict()),
+            msprime.PopulationConfiguration(initial_size=N_S, growth_rate=r_S,
+                                            metadata=self.populations[1].asdict()),
         ]
         self.migration_matrix = [
             [      0, m_B_S],  # NOQA

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -31,7 +31,14 @@ class ModelTestMixin(object):
         # With a recombination_map of None, we simulate a coalescent without
         # recombination in msprime, with no mutation.
         contig = stdpopsim.Contig()
-        samples = self.model.get_samples(*([2] * self.model.num_populations))
+        # Generate vector with 2 samples for each pop with sampling enabled
+        sample_count = []
+        for p in self.model.populations:
+            if p.allow_samples:
+                sample_count.append(2)
+            else:
+                sample_count.append(0)
+        samples = self.model.get_samples(*sample_count)
         engine = stdpopsim.get_default_engine()
         ts = engine.simulate(self.model, contig, samples)
         self.assertEqual(ts.num_populations, self.model.num_populations)
@@ -408,3 +415,52 @@ class TestGenericIM(unittest.TestCase):
         self.assertEqual(model.migration_matrix[1][0], 0.003)
         # check these are the only two nonzero entries in the migration matrix
         self.assertEqual(np.sum(np.array(model.migration_matrix) != 0), 2)
+
+
+class TestPopulationSampling(unittest.TestCase):
+    # Create populations to test on
+    _pop1 = stdpopsim.Population("pop0", "Test pop. 0")
+    _pop2 = stdpopsim.Population("pop1", "Test pop. 1",
+                                 sampling_time=10)
+    _pop3 = stdpopsim.Population("pop2", "Test pop. 2",
+                                 sampling_time=None)
+
+    # Create an empty model to hold populations
+    base_mod = stdpopsim.Model()
+    base_mod.populations = [_pop1, _pop2, _pop3]
+
+    def test_num_sampling_populations(self):
+        self.assertEqual(self.base_mod.num_sampling_populations, 2)
+
+    def test_get_samples(self):
+        test_samples = self.base_mod.get_samples(2, 1)
+        self.assertEqual(len(test_samples), 3)
+        # Check for error when prohibited sampling asked for
+        with self.assertRaises(ValueError):
+            self.base_mod.get_samples(2, 2, 1)
+        # Get the population corresponding to each sample
+        sample_populations = [i.population for i in test_samples]
+        # Check sample populations
+        self.assertEqual(sample_populations, [0, 0, 1])
+        # Test sampling times
+        sample_times = [i.time for i in test_samples]
+        self.assertEqual(sample_times, [0, 0, 10])
+
+    # Test that all sampling populations are specified before non-sampling populations
+    # in the model.populations list
+    def test_population_order(self):
+        for model in stdpopsim.all_models():
+            allow_sample_status = [int(p.allow_samples) for p in model.populations]
+            num_sampling = sum(allow_sample_status)
+            # All sampling populations must be at the start of the list
+            self.assertEqual(sum(allow_sample_status[num_sampling:]), 0)
+
+    # Test that populations are listed in the same order in model.populations and
+    # model.population_configurations
+    def test_population_config_order_equal(self):
+        for model in stdpopsim.all_models():
+            pop_names = [pop.name for pop in model.populations]
+            config_names = [
+                config.metadata["name"] for config in model.population_configurations]
+            for p, c in zip(pop_names, config_names):
+                self.assertEqual(p, c)


### PR DESCRIPTION
Added the ability to set a `sampling_time` attribute for a population that allows for ancient samples. A negative value for this attribute prevents sampling. Updated the models and other functions as necessary. Not sure what tests should be added. 