### PR TITLE
Implement Engine class and remove Model.simulate().

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -51,3 +51,18 @@ these models.
 .. autoclass:: stdpopsim.PiecewiseConstantSize
 
 .. autoclass:: stdpopsim.GenericIM
+
+
+*****************
+Simulation Engine
+*****************
+
+Support for additional simulation engines can be implemented by subclassing
+the abstract :class:`.Engine` class, and registering an instance of the
+subclass with :func:`.register_engine`.
+These are usually not intended to be instantiated directly, but should be
+accessed through the main entrypoint, :func:`.get_engine`.
+
+.. autoclass:: stdpopsim.Engine
+    :members:
+

--- a/docs/examples.py
+++ b/docs/examples.py
@@ -13,7 +13,8 @@ def generic_models_example():
     contig = species.get_contig("chr22", length_multiplier=0.1)
     model = stdpopsim.PiecewiseConstantSize(species.population_size)
     samples = model.get_samples(10)
-    ts = model.simulate(contig, samples)
+    engine = stdpopsim.get_default_engine()
+    ts = engine.simulate(model, contig, samples)
 
 
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -114,7 +114,8 @@ the models directly rather than retrieving them from the catalog.
     contig = species.get_contig("chr22", length_multiplier=0.1)
     model = stdpopsim.PiecewiseConstantSize(species.population_size)
     samples = model.get_samples(10)
-    ts = model.simulate(contig, samples)
+    engine = stdpopsim.get_default_engine()
+    ts = engine.simulate(model, contig, samples)
 
 
 Here, we simulate 10% of human chromosome 22 under a constant size

--- a/stdpopsim/__init__.py
+++ b/stdpopsim/__init__.py
@@ -14,6 +14,7 @@ from . species import *  # NOQA
 from . genomes import *  # NOQA
 from . cache import *  # NOQA
 from . citations import *  # NOQA
+from . engines import * # NOQA
 
 # We import these here to build the catalog, but the internal classes
 # defined are not part of the external API.

--- a/stdpopsim/engines.py
+++ b/stdpopsim/engines.py
@@ -1,0 +1,127 @@
+import logging
+
+import attr
+import msprime
+import stdpopsim
+
+logger = logging.getLogger(__name__)
+
+_registered_engines = {}
+
+
+def register_engine(engine):
+    """
+    Registers the specified simulation engine.
+    """
+    logger.debug(f"Registering simulation engine '{engine.id}'")
+    _registered_engines[engine.id] = engine
+
+
+def get_engine(id):
+    """
+    Returns the simulation engine with the specified id.
+    """
+    if id not in _registered_engines:
+        raise ValueError(f"Simulation engine '{id}' not registered")
+    return _registered_engines[id]
+
+
+def all_engines():
+    """
+    Returns an iterator over all registered simulation engines.
+    """
+    for sim_engine in _registered_engines.values():
+        yield sim_engine
+
+
+@attr.s(frozen=True)
+class Engine(object):
+    """
+    Abstract class representing a simulation engine.
+
+    To implement a new simulation engine, one should inherit from this
+    class. At a minimum, the ``id``, ``name`` and ``citations`` attributes must
+    be set, and the :func:`simulate()` and :func:`get_version()` methods must
+    be implemented. See msprime example in ``engines.py``.
+
+    :ivar id: The unique identifier for the simulation engine.
+    :vartype id: str
+    :ivar name: The name for this engine as it would be used in written text
+        such as the CLI or error messages.
+    :vartype name: str
+    :ivar citations: A list of citations for the simulation engine.
+    :vartype citations: list of :class:`.Citation`
+    """
+
+    def simulate(self, model=None, contig=None, samples=None, **kwargs):
+        """
+        Simulates the model for the specified contig and samples.
+
+        :param model: The demographic model to simulate.
+        :type model: :class:`.Model`
+        :param contig: The contig, defining the length and recombination
+            rate(s).
+        :type contig: :class:`msprime.simulations.Contig`
+        :param samples: The samples to be obtained from the simulation.
+        :type samples: list of :class:`msprime.simulations.Sample`
+        :return: A succinct tree sequence.
+        :rtype: :class:`tskit.trees.TreeSequence`
+        """
+        raise NotImplementedError()
+
+    def get_version(self):
+        """
+        Returns the version of the engine.
+
+        :rtype: str
+        """
+        raise NotImplementedError()
+
+    def add_arguments(self, parser):
+        """
+        Defines engine specific command line parameters.
+
+        If implemented, this function should call :func:`parser.add_argument()`
+        to define engine specific command line parameters. The engine's
+        :func:`simulate()` method should accept keyword arguments matching the
+        names defined here.
+
+        :param parser: A CLI argument parser group.
+        :type parser: :class:`argparse._ArgumentGroup`
+        """
+        pass
+
+
+class _MsprimeEngine(Engine):
+    id = "msprime"
+    name = "msprime"
+    citations = [
+            stdpopsim.Citation(
+                doi="https://doi.org/10.1371/journal.pcbi.1004842",
+                year="2016",
+                author="Kelleher et al."),
+            ]
+
+    def simulate(self, model=None, contig=None, samples=None, seed=None,
+                 **kwargs):
+        return msprime.simulate(
+                samples=samples,
+                recombination_map=contig.recombination_map,
+                mutation_rate=contig.mutation_rate,
+                population_configurations=model.population_configurations,
+                migration_matrix=model.migration_matrix,
+                demographic_events=model.demographic_events,
+                random_seed=seed)
+
+    def get_version(self):
+        return msprime.__version__
+
+
+register_engine(_MsprimeEngine())
+
+
+def get_default_engine():
+    """
+    Returns the default simulation engine (msprime).
+    """
+    return get_engine("msprime")

--- a/stdpopsim/models.py
+++ b/stdpopsim/models.py
@@ -219,21 +219,6 @@ class Model(object):
             samples.extend([msprime.Sample(pop_index, time=0)] * n)
         return samples
 
-    def simulate(self, contig, samples, seed=None):
-        """
-        Simulates this model for the specified contig (defining the recombination
-        map and mutation rate) and samples.
-        """
-        ts = msprime.simulate(
-            samples=samples,
-            recombination_map=contig.recombination_map,
-            mutation_rate=contig.mutation_rate,
-            population_configurations=self.population_configurations,
-            migration_matrix=self.migration_matrix,
-            demographic_events=self.demographic_events,
-            random_seed=seed)
-        return ts
-
 
 # Reusable generic populations
 _pop0 = Population(name="pop0", description="Generic population")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -434,7 +434,9 @@ class TestWriteCitations(unittest.TestCase):
         contig = stdpopsim.Contig()
         species = stdpopsim.get_species("homsap")
         model = species.get_model("ooa_3")
-        stdout, stderr = capture_output(cli.write_citations, contig, model)
+        engine = stdpopsim.get_default_engine()
+        stdout, stderr = capture_output(
+                cli.write_citations, engine, model, contig)
         self.assertEqual(len(stdout), 0)
         # TODO Parse out the output for the model and check that the text is
         # in there.
@@ -444,7 +446,9 @@ class TestWriteCitations(unittest.TestCase):
         species = stdpopsim.get_species("homsap")
         contig = species.get_contig("chr22", genetic_map="HapmapII_GRCh37")
         model = stdpopsim.PiecewiseConstantSize(species.population_size)
-        stdout, stderr = capture_output(cli.write_citations, contig, model)
+        engine = stdpopsim.get_default_engine()
+        stdout, stderr = capture_output(
+                cli.write_citations, engine, model, contig)
         self.assertEqual(len(stdout), 0)
         # TODO Parse out the output for the model and check that the text is
         # in there.

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -1,0 +1,47 @@
+"""
+Tests for simulation engine infrastructure.
+"""
+import unittest
+
+import stdpopsim
+
+
+class TestEngine_API(unittest.TestCase):
+    """
+    Tests for the API exposed for simulation engines.
+    """
+    def _test_engine(self, engine):
+        self.assertIsInstance(engine, stdpopsim.Engine)
+        self.assertIsNotNone(engine.simulate)
+        self.assertNotEqual(len(engine.citations), 0)
+        self.assertNotEqual(len(engine.get_version()), 0)
+
+    def test_get_default_engine(self):
+        engine = stdpopsim.get_default_engine()
+        self._test_engine(engine)
+
+    def test_all_engines(self):
+        for engine in stdpopsim.all_engines():
+            self._test_engine(engine)
+
+    def test_register_engine(self):
+        class MyEngine(stdpopsim.Engine):
+            id = "test-engine"
+            name = "test"
+            citations = []
+        engine1 = MyEngine()
+        stdpopsim.register_engine(engine1)
+        engine2 = stdpopsim.get_engine(engine1.id)
+        self.assertEqual(engine1, engine2)
+        # remove engine to avoid possible problems with other tests
+        del stdpopsim.engines._registered_engines[engine1.id]
+
+    def test_get_engine(self):
+        def fail_func():
+            stdpopsim.get_engine("nonexistent")
+        self.assertRaises(ValueError, fail_func)
+
+    def test_abstract_base_class(self):
+        e = stdpopsim.Engine()
+        self.assertRaises(NotImplementedError, e.simulate)
+        self.assertRaises(NotImplementedError, e.get_version)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -32,7 +32,8 @@ class ModelTestMixin(object):
         # recombination in msprime, with no mutation.
         contig = stdpopsim.Contig()
         samples = self.model.get_samples(*([2] * self.model.num_populations))
-        ts = self.model.simulate(contig, samples)
+        engine = stdpopsim.get_default_engine()
+        ts = engine.simulate(self.model, contig, samples)
         self.assertEqual(ts.num_populations, self.model.num_populations)
 
 

--- a/tests/test_pongo.py
+++ b/tests/test_pongo.py
@@ -15,7 +15,8 @@ class TestPongoIM(unittest.TestCase):
         model = pongo.LockeEtAlPongoIM()
         contig = stdpopsim.Contig()
         samples = model.get_samples(2)
-        ts = model.simulate(contig, samples)
+        engine = stdpopsim.get_default_engine()
+        ts = engine.simulate(model, contig, samples)
         self.assertEqual(ts.num_populations, 2)
 
     def test_debug_runs(self):


### PR DESCRIPTION
This PR is separated into ~~two~~multiple commits. The first adds the ~~`SimulationEngine`~~`Engine` class, retaining API backwards compatibility by making `Model.simulate()` use the default simulation engine. The second commit removes `Model.simulate()` and changes any users of this function so that they first obtain the default simulation engine and use its `simulate()` method. Remaining commits can be squashed in once everyone is happy.