### PR TITLE
Write citations to bibtex

### DIFF
--- a/stdpopsim/citations.py
+++ b/stdpopsim/citations.py
@@ -4,6 +4,7 @@ citation information associated with different entities derived from the
 literature that are used within a simulation.
 """
 import attr
+import urllib.request
 
 
 @attr.s
@@ -25,3 +26,10 @@ class Citation(object):
 
     def __str__(self):
         return f"{self.author}, {self.year}: {self.doi}"
+
+    def fetch_bibtex(self):
+        """Retrieve the bibtex of a citation from Crossref."""
+        req = urllib.request.Request(self.doi)
+        req.add_header("Accept", "text/bibliography; style=bibtex")
+        with urllib.request.urlopen(req) as con:
+            return con.read().decode()

--- a/stdpopsim/cli.py
+++ b/stdpopsim/cli.py
@@ -232,6 +232,16 @@ def write_output(ts, args):
         ts.dump(args.output)
 
 
+def write_bibtex(engine, model, contig, bibtex_file):
+    """
+    Write bibtex for available citations to a file."""
+    for citation in engine.citations:
+        bibtex_file.write(citation.fetch_bibtex())
+
+    for citation in model.citations:
+        bibtex_file.write(citation.fetch_bibtex())
+
+
 def write_citations(engine, model, contig):
     """
     Write out citation information so that the user knows what papers to cite
@@ -239,6 +249,7 @@ def write_citations(engine, model, contig):
     information.
     """
     printerr = functools.partial(print, file=sys.stderr)
+
     # TODO say this better
     printerr(
         "If you use this simulation in published work, please cite the following "
@@ -250,15 +261,16 @@ def write_citations(engine, model, contig):
     for citation in engine.citations:
         printerr(f"\t{citation.author} {citation.year}")
         printerr(f"\t{citation.doi}")
+
     printerr("******************")
     printerr("Genetic map:")
     printerr("******************")
-    printerr("\tTODO")
+    printerr("\tTODO\n")
     # TODO need some way to get a GeneticMap instance from the chromosome. We'll also
     # want to be able to output mutation map, and perhaps other information too, so
     # we want to keep some flexibility for this in mind.
     printerr("Simulation model:", model.name)
-    for citation in model.citations:
+    for citatiion in model.citations:
         printerr("\t", citation, sep="")
 
 
@@ -302,6 +314,12 @@ def add_simulate_species_parser(parser, species):
             "Print descriptions of simulation models and exit. If a model ID "
             "is provided as an argument show help for this model; otherwise "
             "show help for all available models"))
+    species_parser.add_argument(
+        "--bibtex_file",
+        type=argparse.FileType('w'),
+        help="Write citations to a given bib file. This will overwrite the file.",
+        default=None,
+        action='store')
 
     # Set metavar="" to prevent help text from writing out the explicit list
     # of options, which can be too long and ugly.
@@ -398,6 +416,8 @@ def add_simulate_species_parser(parser, species):
         write_output(ts, args)
         if not args.quiet:
             write_citations(engine, model, contig)
+        if args.bibtex_file is not None:
+            write_bibtex(engine, model, contig, args.bibtex_file)
 
     species_parser.set_defaults(runner=run_simulation)
 

--- a/tests/test_citations.py
+++ b/tests/test_citations.py
@@ -1,0 +1,61 @@
+"""
+Test cases for methods related to citations.
+"""
+
+import unittest
+from unittest import mock
+import urllib.error
+
+import stdpopsim
+
+
+class mocked_response():
+    """
+    This exists solely to mock out the response from the
+    urllib.request call so that we can test the bibtex
+    retrieval. The enter and exit methods are for calling
+    it as a context manager."""
+    def __init__(self, code, text):
+        self.code = code
+        self.text = text
+
+    def __enter__(self):
+        return(self)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    def read(self):
+        return(self.text)
+
+    def close(self):
+        pass
+
+
+class TestFetchBibtex(unittest.TestCase):
+    """
+    Test the fetching of bibtex files."""
+    def test_get_bibtex_success(self):
+        # Tests a success
+        citation = stdpopsim.Citation(doi="DOI", author="Authors", year="2000")
+        with mock.patch(
+                'urllib.request.urlopen',
+                return_value=mocked_response(
+                    code=200, text=b'test')):
+            with mock.patch('urllib.request.Request'):
+                bib = citation.fetch_bibtex()
+                self.assertEqual(bib, 'test')
+
+    def test_get_bibtex_bad_connection(self):
+        # Tests an invalid URL
+        # Asserts that it raises a value error.
+        citation = stdpopsim.Citation(doi='DOI', author="Authors", year="2000")
+        with self.assertRaises(ValueError):
+            citation.fetch_bibtex()
+
+    def test_get_bibtex_404(self):
+        # Tests a 404
+        citation = stdpopsim.Citation(doi='http://doi.org/url-does-not-exist',
+                                      author="Authors", year="2000")
+        with self.assertRaises(urllib.error.HTTPError):
+            citation.fetch_bibtex()


### PR DESCRIPTION
I've added an option re: issue #157 (and #144) to convert stored DOIs to `bibtex` on the fly through CrossRef's API and write them to a file within `cli.write_citations`. The way I've done it is pretty straightforward, and hopefully easily understandable. It's a very basic implementation right now, and I'm very open to adding in some more interesting extensions.

If the `bibtex` flag is given with a string, then a connection is opened to that path, the stored DOIs are converted, then written. An internet connection *is required* (and this is checked). The connection overwrites itself each time the program is run, so that we don't have giant files unintentionally.  

If the passed citation is not a valid `stdpopsim.Citation` (or is missing the DOI for some reason) then it fails with a custom `InvalidCitation` exception, and if the DOI is present but the connection to the server fails for whatever reason (either lack of internet access or if the DOI doesn't return a valid page) then it raises a `ConnectionFailed` exception. Hopefully this is sufficiently verbose.

The testing was a little bit more involved but hopefully pretty transparent. I mocked out the `requests.get` function to return a class with the right attributes, so that we can test the cases where

1. Everything works
2. The DOI is missing
3. The connection is bad

I also have a test case for running the whole `cli.write_citations` function, with a mocked out output stream that I test against the mocked out `requests.get`. Lots of mocks. 

I rebased against master, and squashed. Let me know what everyone thinks! 

Some further thoughts:

- I introduced a dependency on `requests` which might not be the greatest idea, given our pretty minimal set of dependencies. If anyone has any thoughts for how we could do this differently and get rid of the dependency, please let me know!
- The patch test has failed, but to my knowledge I tested every line in the diff. A bit confused.