### PR TITLE
Added page showing CLI options using sphinx-argparse.

### DIFF
--- a/docs/cli_arguments.rst
+++ b/docs/cli_arguments.rst
@@ -1,0 +1,10 @@
+.. _sec_cli_args:
+
+====================
+Command-line options
+====================
+
+.. argparse::
+	:module: stdpopsim.cli
+	:func: stdpopsim_cli_parser
+	:prog: stdpopsim

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,6 +65,7 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
     'speciescatalog',
+    'sphinxarg.ext',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ Welcome to stdpopsim's documentation!
    installation
    catalog
    tutorial
+   cli_arguments
    api
    development
    changelogs


### PR DESCRIPTION
Closes #197 and #118; uses a very vanilla implementation of sphinx-argparse to show command-line options in the docs. Hopefully this will make also make it easier for us to spot which parts of the CLI help could be improved (see #215).

I have to say, I don't think that the default way that sphinx has organised and rendered these is going to be very clear or accessible for users of `stdpopsim`. I don't even know what 'Positional' and 'Named' arguments are, but these get their own section heading here. All of the simulation-specific commands are hidden inside the 'Subcommands' subsection.

Nevertheless, might be useful to pull this in now so that others can see and comment on it, and we can address these issues in a later pull request.