### PR TITLE
Tutorial generic vcf

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -118,129 +118,118 @@ The Python interface
 Running a prexisting model
 --------------------------
 
-.. todo::
-    Add up to date code
-
-.. TODO port these old examples.
-
-.. ********
-.. Examples
-.. ********
-
-.. This content should go into a tutorial or somewhere else, but for now it's
-.. useful to keep a couple of short examples here for reference and
-.. to motivate the API.
-
-.. Models and genome data are split by species. Information about the genomes
-.. of a particular species is held in the ``genome`` class variable. So,
-.. suppose we wish to perform a simple simulation of human chromosome 22, we
-.. might have:
-
-.. .. code-block:: python
-
-..     import msprime
-..     from stdpopsim import homo_sapiens
-
-..     chrom = homo_sapiens.genome.chromosomes["chr22"]
-..     ts = msprime.simulate(
-..         sample_size=10,
-..         recombination_rate=chrom.default_recombination_rate,
-..         mutation_rate=chrom.default_mutation_rate,
-..         length=chrom.length)
-
-.. (This should be a very quick simulation, and the result will have very few
-.. variants, because although it performs a coalescent simulation of
-.. a 51,304,566bp chromosome, it does this with the effective population size of
-.. `Ne=1`.)
-
-.. The chromosome definitions also aware of recombination maps,
-.. which must be first downloaded. The default for ``homo_sapiens`` is ``HapmapII_GRCh37``,
-.. which we can find out, then download it as follows
-.. (the maps are stored in your ``~/.cache/stdpopsim/`` directory):
-
-.. .. code-block:: python
-
-..    homo_sapiens.genome.default_genetic_map
-..    # 'HapmapII_GRCh37'
-..    gmap = homo_sapiens.HapmapII_GRCh37()
-..    gmap.download()
-
-
-.. After this has been done (once only), we can run simulations using this genetic map as follows:
-
-.. .. code-block:: python
-
-..     chrom = homo_sapiens.genome.chromosomes["chr22"]
-..     ts = msprime.simulate(
-..         sample_size=10,
-..         mutation_rate=chrom.default_mutation_rate,
-..         recombination_map=chrom.recombination_map())
-
-.. Recombination maps will be downloaded on demand and cached in a
-.. platform-appropriate user cache directory (e.g., ``$HOME/.cache/stdpopsim`` on
-.. Linux). In this example we didn't specify which recombination map we want, and so the
-.. API will use the default. We can also ask for specific maps, if we want:
-
-.. .. code-block:: python
-
-..     chrom = homo_sapiens.genome.chromosomes["chr22"]
-..     ts = msprime.simulate(
-..         sample_size=10,
-..         mutation_rate=chrom.default_mutation_rate,
-..         recombination_map=chrom.recombination_map("HapmapII_GRCh37"))
-
-
-.. Demographic models can also be used. For example
-
-.. .. code-block:: python
-
-..     import stdpopsim
-..     from stdpopsim import homo_sapiens
-
-..     chrom = homo_sapiens.genome.chromosomes["chr22"]
-..     model = homo_sapiens.GutenkunstThreePopOutOfAfrica()
-..     # One sample each from YRI, CEU and CHB.
-..     samples = [msprime.Sample(population=j, time=0) for j in range(3)]
-..     ts = msprime.simulate(
-..         samples=samples,
-..         recombination_map=chrom.recombination_map(),
-..         mutation_rate=chrom.default_mutation_rate,
-..         **model.asdict())
-
-.. (This simulation now has a realistic effective population size,
-.. so will produce thousands of variant sties, but still runs very fast.)
-
-
 
 .. _sec_tutorial_generic_models:
 
-**************
-Generic models
-**************
+-------------------------------------------------
+Running a generic model and outputting a vcf file
+-------------------------------------------------
 
-The previous sections showed how to simulate population genetic models that have
-been published for particular species. It is also sometimes useful to simulate
-more generic models. We can still use the information for particular species to
-do this; the only difference is that we instantiate the models directly rather
-than retrieving them from the :ref:`catalog <sec_catalog>`.
+In this example, we will use the ``stdpopsim`` API to simulate a generic
+model for a particular species. We will use the information for a particular
+species and instantiate the model directly.
 
+Here, we will simulate 10% of human chromosome 22 under a constant size
+population model, using the current best estimate of the human
+effective population size from the :ref:`sec_catalog`.
+
+
+1. Import the necessary packages
 
 .. code-block:: python
 
-    species = stdpopsim.get_species("homsap")
-    contig = species.get_contig("chr22", length_multiplier=0.1)
-    model = stdpopsim.PiecewiseConstantSize(species.population_size)
-    samples = model.get_samples(10)
-    engine = stdpopsim.get_default_engine()
-    ts = engine.simulate(model, contig, samples)
+    >>> import stdpopsim
 
+2. Get the particular species information. In this case, we are using
+`Homo sapiens`, which has the id "homsap".
+But, you could use any species from the :ref:`sec_catalog`.
 
-Here, we simulate 10% of human chromosome 22 under a constant size
-population model, using the current best estimate of the human
-effective population size from the **TODO add crossref to catalog section**
+.. code-block:: python
 
-.. :ref:`sec_catalog_homo_sapiens_genome`
+    >>> species = stdpopsim.get_species("homsap")
 
+3. Set the contig length. We are simulating 0.1 x chromosome 22,
+which is about 5Mb. Again, you could use a fraction of any of the
+chromosomes listed in the :ref:`sec_catalog`, keeping in mind that
+larger contigs will take longer to simulate.
 
+.. code-block:: python
+
+    >>> contig = species.get_contig("chr22", length_multiplier=0.1)
+
+4. Set the model as the generic piecewise constant size model, using the
+predefined human effective population size (see :ref:`sec_catalog`).
+Since we are providing one effective population size, the model is constant
+population size for one population over time.
+
+.. code-block:: python
+
+    >>> model = stdpopsim.PiecewiseConstantSize(species.population_size)
+
+5. Set the number of samples and set the simulation engine.
+In this case we will simulate 10 samples and use the default simulator,
+which is `msprime`. But, you can go crazy with the sample size!
+`msprime` is great at simulating large samples!
+
+.. code-block:: python
+
+    >>> samples = model.get_samples(10)
+    >>> engine = stdpopsim.get_default_engine()
+
+6. Simulate the model with the contig length and number of samples we defined above.
+We capture the simulation results in a tree sequence object
+(:class:`tskit.TreeSequence`).
+
+.. code-block:: python
+
+    >> ts = engine.simulate(model, contig, samples)
+
+7. We can now do some simple checks that our simulation worked with
+`tskit
+<https://tskit.readthedocs.io>`__.
+
+.. code-block:: python
+
+    >>> ts.num_samples
+    10
+    >>> ts.num_populations
+    1
+    >>> ts.num_mutations
+    6197
+    >>> ts.num_trees
+    6863
+
+As expected, there are 10 samples in one population. We can also see that 6197 mutations
+and 6863 trees were simulated (since we are not using a seed here, the number of mutations
+and trees will be slightly different for you). Try running the simulation again, and notice
+that the number of samples and populations stays the same, while the number of mutations
+and trees changes.
+
+8. In addition to working directly with the simulated tree squence, we can also output
+other common formats used for population genetics analyses.
+We can use ``tskit`` to convert the tree sequence to a vcf file called "foo.vcf".
+See the tskit documentation (:meth:`tskit.TreeSequence.write_vcf`) for more information.
+
+.. code-block:: python
+
+    >>> with open("foo.vcf", "w") as vcf_file:
+    >>>    ts.write_vcf(vcf_file)
+
+Taking a look at the vcf file, we see something like this:
+
+.. code-block::
+
+    ##fileformat=VCFv4.2
+    ##source=tskit 0.2.2
+    ##FILTER=<ID=PASS,Description="All filters passed">
+    ##contig=<ID=1,length=5130457>
+    ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+    #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	tsk_0	tsk_1	tsk_2	tsk_3	tsk_4	tsk_5	tsk_6	tsk_7	tsk_8	tsk_9
+    1	96	.	0	1	.	PASS	.	GT	0	0	1	0	1	0	0	0	1	0
+    1	129	.	0	1	.	PASS	.	GT	0	0	0	0	0	0	0	0	1	0
+    1	436	.	0	1	.	PASS	.	GT	0	0	0	0	0	1	0	0	0	0
+    1	466	.	0	1	.	PASS	.	GT	0	0	1	0	1	0	0	0	0	0
+    1	558	.	0	1	.	PASS	.	GT	0	0	0	0	0	0	0	0	1	0
+    1	992	.	0	1	.	PASS	.	GT	1	1	0	1	0	1	1	1	0	1
 
 


### PR DESCRIPTION
Add a tutorial for python API generic model and output a vcf.

I was originally intending to also show how to output a tped file. But, on second thought, doesn't seem that useful to output a tped once you already show how to get a vcf file. PLINK takes vcf and can convert to a tped.

closes https://github.com/popgensims/stdpopsim/issues/173