### PR TITLE
Small bibtex changes

### DIFF
--- a/stdpopsim/catalog/homo_sapiens.py
+++ b/stdpopsim/catalog/homo_sapiens.py
@@ -278,7 +278,7 @@ class _TennessenTwoPopOutOfAfrica(HomoSapiensModel):
         stdpopsim.Citation(
             author="Fu et al.",
             year=2013,
-            doi="https://doi.org/10.1038 nature11690")
+            doi="https://doi.org/10.1038/nature11690")
     ]
 
     def __init__(self):

--- a/stdpopsim/cli.py
+++ b/stdpopsim/cli.py
@@ -237,9 +237,12 @@ def write_bibtex(engine, model, contig, bibtex_file):
     Write bibtex for available citations to a file."""
     for citation in engine.citations:
         bibtex_file.write(citation.fetch_bibtex())
-
+    if contig.genetic_map is not None:
+        for citation in contig.genetic_map.citations:
+            bibtex_file.write(citation.fetch_bibtex())
     for citation in model.citations:
         bibtex_file.write(citation.fetch_bibtex())
+    bibtex_file.close()
 
 
 def write_citations(engine, model, contig):
@@ -304,7 +307,7 @@ def add_simulate_species_parser(parser, species):
             "is provided as an argument show help for this model; otherwise "
             "show help for all available models"))
     species_parser.add_argument(
-        "--bibtex_file",
+        "-b", "--bibtex-file",
         type=argparse.FileType('w'),
         help="Write citations to a given bib file. This will overwrite the file.",
         default=None,


### PR DESCRIPTION
A few small things here:

- Fixed a typo in the Tennessen doi
- Writes genetic map citations to bibtex with a test
- Changes name of bibtex option to `bibtex-file` and adds the short `b` option