### PR TITLE
Change mutations to ACGT

### DIFF
--- a/stdpopsim/engines.py
+++ b/stdpopsim/engines.py
@@ -104,14 +104,17 @@ class _MsprimeEngine(Engine):
 
     def simulate(self, model=None, contig=None, samples=None, seed=None,
                  **kwargs):
-        return msprime.simulate(
+        ts = msprime.simulate(
                 samples=samples,
                 recombination_map=contig.recombination_map,
-                mutation_rate=contig.mutation_rate,
                 population_configurations=model.population_configurations,
                 migration_matrix=model.migration_matrix,
                 demographic_events=model.demographic_events,
                 random_seed=seed)
+        mutation_model = msprime.InfiniteSites(msprime.NUCLEOTIDES)
+        return msprime.mutate(
+            ts, rate=contig.mutation_rate, model=mutation_model,
+            random_seed=seed)
 
     def get_version(self):
         return msprime.__version__


### PR DESCRIPTION
For discussion; see #241 for more details.

This is tricky, because it cuts across our nice clean "Engine" interface. Presumably, we'll want to put mutations down on tree sequences output by SLiM as well, and therefore we probably want to restructure the API a bit for dealing with mutations in a forward compatible way. The question is, do we want to do this before the first release?

Also, do we want to default to 0/1 mutations or ACGT? @petrelharp, @andrewkern, what's your take on this?