### PR TITLE
Added sphinxcontrib-programoutput directives in tutorials

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,4 +56,5 @@ jobs:
       - run:
           name: Build docs
           command: |
+            source venv/bin/activate
             cd docs && make && make singlehtml

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,6 +66,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'speciescatalog',
     'sphinxarg.ext',
+    'sphinxcontrib.programoutput'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -48,7 +48,7 @@ help+wanted%22>`_
 To get started helping with ``stdpopsim`` development, please read the
 following sections to learn how to contribute.
 
-
+.. sec_development_installation:
 
 ************
 Installation
@@ -63,7 +63,9 @@ For ``pip`` users, install the packages required for development using::
 
     $ python3 -m pip install -r requirements/development.txt
 
+You can then install the development version of ``stdpopsim`` like this::
 
+    $ python3 setup.py install
 
 For ``conda`` users, you will need to add the conda-forge channel to your conda
 environment and then should be able to install the development requirements using::
@@ -569,4 +571,6 @@ It is defined in the ``docs`` directory.
 To build the documentation type ``make`` in the ``docs`` directory. This should build
 HTML output in the ``_build/html/`` directory.
 
+.. note::
 
+    You will need ``stdpopsim`` to be installed for the build to work.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -28,20 +28,17 @@ by ``stdpopsim``. The first step for using the CLI is to select the species that
 you are interested in simulating data for. In order to see which species are
 available run
 
-.. code-block:: console
-
-    $ stdpopsim --help
+.. command-output:: stdpopsim --help
 
 This shows the species currently supported by ``stdpopsim``. This means that
 ``stdpopsim`` knows various traits of these species including chromosome size
 and recombination rates. Once we've selected a species, in this case humans, we
 can look at the help again as follows.
 
-.. code-block:: console
+.. command-output:: stdpopsim homsap --help
+    :ellipsis: 20
 
-    $ stdpopsim homsap --help
-
-For conciseness we do not show the output here but this time you should see a
+For conciseness we do not show all the output here but this time you should see a
 different output which shows options for performing the simulation itself and
 the species default parameters. This includes selecting the demographic model,
 chromosome, recombination map, and number of samples. 
@@ -66,9 +63,8 @@ tree-sequence formated output should be written to the file ``foo.ts`` with the
 Say we want to use a specific demographic model. We look up the available models
 using the ``--help-models`` flag:
 
-.. code-block:: console
-
-    $ stdpopsim homsap --help-models
+.. command-output:: stdpopsim homsap --help-models
+    :ellipsis: 20
 
 This gives all of the possible demographic models we could simulate. We choose
 the the two population out-of-Africa model from `Tennesen et al. (2012)
@@ -257,9 +253,8 @@ and then estimate the genetic divergence between each population pair.
 First, let's use the ``--help-models`` option to see the selection of demographic
 models available to us:
 
-.. code-block:: console
-
-    $ stdpopsim homsap --help-models
+.. command-output:: stdpopsim homsap --help-models
+    :ellipsis: 20
 
 This prints detailed information about all of the available models to
 the terminal.
@@ -273,9 +268,7 @@ European, Asian and African-American groups.
 Using the ``--help-genetic-maps`` option, we can also see what recombination maps
 are available:
 
-.. code-block:: console
-
-    $ stdpopsim homsap --help-genetic-maps
+.. command-output:: stdpopsim homsap --help-genetic-maps
 
 Let's go with ``HapmapII_GRCh37``.
 The next command simulates 4 samples of chromosome 1 from each of the four

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -6,6 +6,7 @@ setuptools_scm
 sphinx
 sphinx-argparse
 sphinx_rtd_theme
+sphinxcontrib-programoutput
 msprime
 kastore
 attrs

--- a/requirements/rtd.txt
+++ b/requirements/rtd.txt
@@ -4,6 +4,7 @@ attrs
 appdirs
 numpy
 sphinx-argparse
+sphinxcontrib-programoutput
 # These are all needed to import the CLI for running 
 # sphinx-argparse.
 tskit


### PR DESCRIPTION
Closes #266 

This works locally, but to get it running on RTD I suspect you'll also need to tell it that we are using the `sphinxcontrib.programoutput` extension, and to make `stdpopsim` available to it so that the commands can be compiled remotely.

A few thoughts I had while doing this:

 - This will contribute to massive bloat if we use it indiscriminately. I propose that *only help output* should be displayed in this way, and this should be truncated to 20 lines unless abs necessary.

I don't think it's a good idea to be running `stdpopsim` simulations themselves within the program-output blocks -- some of the ones in the existing tutes take some time to run, and I'm not sure what RTD would do with the output files that these commands are supposed to create.

 - Presumably, we wanted to do this to save us from having to continually edit docs as we also edit the help output (#215). It's not totally clear to me that RTD is going to just automatically update these docs, though -- I'm guessing it would need to be (manually) pointed to an up-to-date stdpopsim installation for this to happen? 

More generally, I don't know much about how ``stdpopsim`` will work on whatever RTD uses to execute these commands...