### PR TITLE
add reference for ecoli generation time fixes #291

### DIFF
--- a/stdpopsim/catalog/e_coli.py
+++ b/stdpopsim/catalog/e_coli.py
@@ -14,6 +14,11 @@ _lapierre_et_al = stdpopsim.Citation(
     year="2016",
     doi="https://doi.org/10.1093/molbev/msw048")
 
+_sezonov_et_al = stdpopsim.Citation(
+    author="Sezonov et al.",
+    year="2007",
+    doi="https://doi.org/10.1128/JB.01368-07")
+
 _chromosomes = []
 _chromosomes.append(stdpopsim.Chromosome(
         id=None,
@@ -32,9 +37,8 @@ _species = stdpopsim.Species(
     id="esccol",
     name="Escherichia coli",
     genome=_genome,
-    # TODO reference for these
     generation_time=0.00003805175,  # 1.0 / (525600 min/year / 20 min/gen)
-    generation_time_citations=[],  # FIXME
+    generation_time_citations=[_sezonov_et_al],
     population_size=1.8e8,
     population_size_citations=[_lapierre_et_al])
 


### PR DESCRIPTION
This should be a good reference for the generation time in E coli under lab conditions:

https://dx.doi.org/10.1128/JB.01368-07

However, there is also a good reference for (alternative) generation times in wild populations:

https://dx.doi.org/10.1098%2Frspb.2018.0789

I only included the first one.
