### PR TITLE
added citations for drosophila attributes

### DIFF
--- a/stdpopsim/catalog/drosophila_melanogaster.py
+++ b/stdpopsim/catalog/drosophila_melanogaster.py
@@ -26,12 +26,23 @@ chrY   3667352
 chrM   19524
 """
 
+# citations
+_LiAndStephan = stdpopsim.Citation(
+    author="Li et al.",
+    year=2006,
+    doi="https://doi.org/10.1371/journal.pgen.0020166")
+
+_SchriderEtAl = stdpopsim.Citation(
+    author="Schrider et al.",
+    year=2013,
+    doi="https://doi.org/10.1534/genetics.113.151670")
+
 _chromosomes = []
 for line in _chromosome_data.splitlines():
     name, length = line.split()[:2]
     _chromosomes.append(stdpopsim.Chromosome(
         id=name, length=int(length),
-        mutation_rate=8.4e-9,  # WRONG!, underestimate used in S&S
+        mutation_rate=5.49e-9,  # citation: _SchriderEtAl
         recombination_rate=8.4e-9))  # WRONG, underestimate used in S&S!
 
 
@@ -45,9 +56,10 @@ _species = stdpopsim.Species(
     id="dromel",
     name="Drosophila melanogaster",
     genome=_genome,
-    # TODO reference for these
     generation_time=0.1,
-    population_size=10**4)  # TODO: This is wildly wrong, right?
+    generation_time_citations=[_LiAndStephan],
+    population_size=1720600,
+    population_size_citations=[_LiAndStephan])
 
 stdpopsim.register_species(_species)
 
@@ -161,11 +173,7 @@ def _ooa_2():
         from Li and Stephan (2006).
     """
     populations = [_afr_population, _eur_population]
-    citations = [stdpopsim.Citation(
-        author="Li et al.",
-        year=2006,
-        doi="https://doi.org/10.1371/journal.pgen.0020166")
-    ]
+    citations = [_LiAndStephan]
     generation_time = _species.generation_time
     citations.extend(_species.generation_time_citations)
 

--- a/tests/test_drosophila_melanogaster.py
+++ b/tests/test_drosophila_melanogaster.py
@@ -13,7 +13,7 @@ class TestSpecies(unittest.TestCase, test_species.SpeciesTestMixin):
     species = stdpopsim.get_species("dromel")
 
     def test_basic_attributes(self):
-        self.assertEqual(self.species.population_size, 10**4)
+        self.assertEqual(self.species.population_size, 1720600)
         self.assertEqual(self.species.generation_time, 0.1)
 
 


### PR DESCRIPTION
conveniently the Li and Stephan paper from 2006 publishes Ne estimates from African flies and a generation time (10 gens/yr). I've used that here. I've also included the Schrider et al mutation rate estimate.