### PR TITLE
Don't test for the species specific citations in the output.

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -515,14 +515,10 @@ class TestWriteCitations(unittest.TestCase):
         if genetic_map is None:
             genetic_map = stdpopsim.GeneticMap(species.id, citations=[])
         for citations, assert_msg in zip(
-                (engine.citations, model.citations, genetic_map.citations,
-                    species.generation_time_citations,
-                    species.population_size_citations),
+                (engine.citations, model.citations, genetic_map.citations),
                 (f"engine citation not written for {engine.id}",
                     f"model citation not written for {model.id}",
-                    f"genetic map citation not written for {genetic_map.name}",
-                    f"generation time citation not written for {species.id}",
-                    f"population size citation not written for {species.id}")):
+                    f"genetic map citation not written for {genetic_map.name}")):
             for citation in citations:
                 self.assertTrue(citation.author in stderr, msg=assert_msg)
                 self.assertTrue(str(citation.year) in stderr, msg=assert_msg)


### PR DESCRIPTION
This test is bogus, because a model need not use the species citations,
in which case the species citations should absolutely not be written.
But there's no way to determine if a model has imported the species citations
nor not.

See discussion in #316.