### PR TITLE
Add a `Citation.reason` attribute.

### DIFF
--- a/stdpopsim/catalog/arabidopsis_thaliana.py
+++ b/stdpopsim/catalog/arabidopsis_thaliana.py
@@ -46,12 +46,14 @@ _species = stdpopsim.Species(
     generation_time_citations=[stdpopsim.Citation(
         doi="https://doi.org/10.1890/0012-9658(2002)083[1006:GTINSO]2.0.CO;2",
         year="2002",
-        author="Donohue")],
+        author="Donohue",
+        reasons={stdpopsim.CiteReason.GEN_TIME})],
     population_size=10**4,
     population_size_citations=[stdpopsim.Citation(
         doi="https://doi.org/10.1016/j.cell.2016.05.063",
         year="2016",
-        author="1001GenomesConsortium")]
+        author="1001GenomesConsortium",
+        reasons={stdpopsim.CiteReason.POP_SIZE})]
     )
 
 stdpopsim.register_species(_species)
@@ -76,7 +78,8 @@ _gm = stdpopsim.GeneticMap(
     citations=[stdpopsim.Citation(
         doi="https://doi.org/10.1038/hdy.2011.95",
         author="Salome et al.",
-        year=2012)]
+        year=2012,
+        reasons={stdpopsim.CiteReason.GEN_MAP})]
     )
 _species.add_genetic_map(_gm)
 
@@ -133,7 +136,8 @@ def _sma_1pop():
         citations=[stdpopsim.Citation(
             author="Durvasula et al.",
             year=2017,
-            doi="https://doi.org/10.1073/pnas.1616736114")
+            doi="https://doi.org/10.1073/pnas.1616736114",
+            reasons={stdpopsim.CiteReason.DEM_MODEL})
         ],
         generation_time=1,
         demographic_events=demographic_events,
@@ -167,7 +171,8 @@ def _afr_2epoch():
         citations=[stdpopsim.Citation(
             author="Huber et al.",
             year=2018,
-            doi="https://doi.org/10.1038/s41467-018-05281-7")
+            doi="https://doi.org/10.1038/s41467-018-05281-7",
+            reasons={stdpopsim.CiteReason.DEM_MODEL})
         ],
         generation_time=1,
         population_configurations=[
@@ -209,7 +214,8 @@ def _afr_3epoch():
         citations=[stdpopsim.Citation(
             author="Huber et al.",
             year=2018,
-            doi="https://doi.org/10.1038/s41467-018-05281-7")
+            doi="https://doi.org/10.1038/s41467-018-05281-7",
+            reasons={stdpopsim.CiteReason.DEM_MODEL})
         ],
         generation_time=1,
         population_configurations=[

--- a/stdpopsim/catalog/drosophila_melanogaster.py
+++ b/stdpopsim/catalog/drosophila_melanogaster.py
@@ -57,9 +57,11 @@ _species = stdpopsim.Species(
     name="Drosophila melanogaster",
     genome=_genome,
     generation_time=0.1,
-    generation_time_citations=[_LiAndStephan],
+    generation_time_citations=[
+        _LiAndStephan.because(stdpopsim.CiteReason.GEN_TIME)],
     population_size=1720600,
-    population_size_citations=[_LiAndStephan])
+    population_size_citations=[
+        _LiAndStephan.because(stdpopsim.CiteReason.POP_SIZE)])
 
 stdpopsim.register_species(_species)
 
@@ -84,7 +86,8 @@ _gm = stdpopsim.GeneticMap(
     citations=[stdpopsim.Citation(
         author="Comeron et al",
         doi="https://doi.org/10.1371/journal.pgen.1002905",
-        year=2012)]
+        year=2012,
+        reasons={stdpopsim.CiteReason.GEN_MAP})]
     )
 
 _species.add_genetic_map(_gm)
@@ -120,7 +123,8 @@ def _afr_3epoch():
     citations = [stdpopsim.Citation(
         author="Sheehan and Song",
         year=2016,
-        doi="https://doi.org/10.1371/journal.pcbi.1004845")
+        doi="https://doi.org/10.1371/journal.pcbi.1004845",
+        reasons={stdpopsim.CiteReason.DEM_MODEL})
     ]
     generation_time = _species.generation_time
     citations.extend(_species.generation_time_citations)
@@ -173,7 +177,7 @@ def _ooa_2():
         from Li and Stephan (2006).
     """
     populations = [_afr_population, _eur_population]
-    citations = [_LiAndStephan]
+    citations = [_LiAndStephan.because(stdpopsim.CiteReason.DEM_MODEL)]
     generation_time = _species.generation_time
     citations.extend(_species.generation_time_citations)
 

--- a/stdpopsim/catalog/drosophila_melanogaster.py
+++ b/stdpopsim/catalog/drosophila_melanogaster.py
@@ -50,7 +50,10 @@ for line in _chromosome_data.splitlines():
 # class:`stdpopsim.Genome` definition for D. melanogaster. Chromosome length data is
 # based on `dm6 <https://www.ncbi.nlm.nih.gov/assembly/GCF_000001215.4/>`_.
 
-_genome = stdpopsim.Genome(chromosomes=_chromosomes)
+_genome = stdpopsim.Genome(
+        chromosomes=_chromosomes,
+        mutation_rate_citations=[
+            _SchriderEtAl.because(stdpopsim.CiteReason.MUT_RATE)])
 
 _species = stdpopsim.Species(
     id="DroMel",

--- a/stdpopsim/catalog/e_coli.py
+++ b/stdpopsim/catalog/e_coli.py
@@ -38,8 +38,10 @@ _species = stdpopsim.Species(
     name="Escherichia coli",
     genome=_genome,
     generation_time=0.00003805175,  # 1.0 / (525600 min/year / 20 min/gen)
-    generation_time_citations=[_sezonov_et_al],
+    generation_time_citations=[
+        _sezonov_et_al.because(stdpopsim.CiteReason.GEN_TIME)],
     population_size=1.8e8,
-    population_size_citations=[_lapierre_et_al])
+    population_size_citations=[
+        _lapierre_et_al.because(stdpopsim.CiteReason.POP_SIZE)])
 
 stdpopsim.register_species(_species)

--- a/stdpopsim/catalog/homo_sapiens.py
+++ b/stdpopsim/catalog/homo_sapiens.py
@@ -96,7 +96,8 @@ _gm = stdpopsim.GeneticMap(
         stdpopsim.Citation(
             doi="https://doi.org/10.1038/nature06258",
             year=2007,
-            author="1000 Genomes Project consortium"),
+            author="1000 Genomes Project consortium",
+            reasons={stdpopsim.CiteReason.GEN_MAP}),
         ]
     )
 _species.add_genetic_map(_gm)
@@ -116,7 +117,8 @@ _gm = stdpopsim.GeneticMap(
         stdpopsim.Citation(
             year=2010,
             author="Kong et al",
-            doi="https://doi.org/10.1038/nature09525")]
+            doi="https://doi.org/10.1038/nature09525",
+            reasons={stdpopsim.CiteReason.GEN_MAP})]
     )
 # TODO add a URL citation (see above) here for this:
 # "Please see https://www.decode.com/addendum/ for more details."),
@@ -168,7 +170,8 @@ def _ooa_3():
     citations = [stdpopsim.Citation(
         author="Gutenkunst et al.",
         year=2009,
-        doi="https://doi.org/10.1371/journal.pgen.1000695")
+        doi="https://doi.org/10.1371/journal.pgen.1000695",
+        reasons={stdpopsim.CiteReason.DEM_MODEL})
     ]
 
     generation_time = _species.generation_time
@@ -263,11 +266,12 @@ def _ooa_2():
         stdpopsim.Population(name="EUR", description="European Americans")
     ]
     citations = [
-        _tennessen_et_al,
+        _tennessen_et_al.because(stdpopsim.CiteReason.DEM_MODEL),
         stdpopsim.Citation(
             author="Fu et al.",
             year=2013,
-            doi="https://doi.org/10.1038/nature11690")
+            doi="https://doi.org/10.1038/nature11690",
+            reasons={stdpopsim.CiteReason.DEM_MODEL})
     ]
 
     generation_time = _species.generation_time
@@ -354,7 +358,7 @@ def _african():
     populations = [
         stdpopsim.Population(name="AFR", description="African"),
     ]
-    citations = [_tennessen_et_al]
+    citations = [_tennessen_et_al.because(stdpopsim.CiteReason.DEM_MODEL)]
 
     generation_time = _species.generation_time
     citations.extend(_species.generation_time_citations)
@@ -419,7 +423,8 @@ def _america():
         stdpopsim.Citation(
             author="Browning et al.",
             year=2011,
-            doi="http://dx.doi.org/10.1371/journal.pgen.1007385")
+            doi="http://dx.doi.org/10.1371/journal.pgen.1007385",
+            reasons={stdpopsim.CiteReason.DEM_MODEL})
     ]
 
     generation_time = _species.generation_time
@@ -545,7 +550,8 @@ def _ooa_archaic():
         stdpopsim.Citation(
             author="Ragsdale and Gravel",
             year=2019,
-            doi="https://doi.org/10.1371/journal.pgen.1008204")
+            doi="https://doi.org/10.1371/journal.pgen.1008204",
+            reasons={stdpopsim.CiteReason.DEM_MODEL})
     ]
 
     # First we set out the maximum likelihood values of the various parameters
@@ -702,7 +708,8 @@ def _zigzag():
         stdpopsim.Citation(
             author="Schiffels and Durbin",
             year=2014,
-            doi="https://doi.org/10.1038/ng.3015")
+            doi="https://doi.org/10.1038/ng.3015",
+            reasons={stdpopsim.CiteReason.DEM_MODEL})
     ]
 
     generation_time = 29
@@ -831,7 +838,8 @@ def _kamm_ancient_eurasia():
         stdpopsim.Citation(
             author="Kamm et al.",
             year=2019,
-            doi="https://doi.org/10.1080/01621459.2019.1635482")
+            doi="https://doi.org/10.1080/01621459.2019.1635482",
+            reasons={stdpopsim.CiteReason.DEM_MODEL})
     ]
 
     # Times are provided in years, so we convert into generations.

--- a/stdpopsim/catalog/homo_sapiens.py
+++ b/stdpopsim/catalog/homo_sapiens.py
@@ -148,7 +148,8 @@ _chb_population = stdpopsim.Population(
 _tennessen_et_al = stdpopsim.Citation(
     author="Tennessen et al.",
     year=2012,
-    doi="https://doi.org/10.1126/science.1219240")
+    doi="https://doi.org/10.1126/science.1219240",
+    reasons={stdpopsim.CiteReason.DEM_MODEL})
 
 
 def _ooa_3():
@@ -266,7 +267,7 @@ def _ooa_2():
         stdpopsim.Population(name="EUR", description="European Americans")
     ]
     citations = [
-        _tennessen_et_al.because(stdpopsim.CiteReason.DEM_MODEL),
+        _tennessen_et_al,
         stdpopsim.Citation(
             author="Fu et al.",
             year=2013,
@@ -358,7 +359,7 @@ def _african():
     populations = [
         stdpopsim.Population(name="AFR", description="African"),
     ]
-    citations = [_tennessen_et_al.because(stdpopsim.CiteReason.DEM_MODEL)]
+    citations = [_tennessen_et_al]
 
     generation_time = _species.generation_time
     citations.extend(_species.generation_time_citations)

--- a/stdpopsim/citations.py
+++ b/stdpopsim/citations.py
@@ -3,8 +3,21 @@ Citation management for stdpopsim. Provides utilities for printing
 citation information associated with different entities derived from the
 literature that are used within a simulation.
 """
-import attr
+import sys
+import collections
 import urllib.request
+
+import attr
+
+
+class CiteReason(object):
+    ENGINE = "simulation engine"
+    DEM_MODEL = "demographic model"
+    GEN_MAP = "genetic map"
+    POP_SIZE = "population size"
+    GEN_TIME = "generation time"
+    MUT_RATE = "mutation rate"
+    REC_RATE = "recombination rate"
 
 
 @attr.s
@@ -23,9 +36,36 @@ class Citation(object):
     doi = attr.ib(type=str, kw_only=True)
     author = attr.ib(type=str, kw_only=True)
     year = attr.ib(type=int, kw_only=True)
+    reasons = attr.ib(factory=set, kw_only=True)
 
     def __str__(self):
         return f"{self.author}, {self.year}: {self.doi}"
+
+    def print(self, file=sys.stdout):
+        print("[", end="", file=file)
+        for i, reason in enumerate(self.reasons):
+            end = "" if i == len(self.reasons)-1 else ", "
+            print(reason, end=end, file=file)
+        print("]", file=file)
+        print("  "+str(self), file=file)
+
+    def because(self, reasons):
+        """Returns a new Citation with the given reasons."""
+        if not isinstance(reasons, set):
+            reasons = {reasons}
+        return self.__class__(
+                author=self.author, year=self.year, doi=self.doi,
+                reasons=self.reasons | reasons)
+
+    @staticmethod
+    def merge(citations):
+        """Returns a deduplicated list of Citation objects."""
+        cset = collections.OrderedDict()
+        for citation in citations:
+            if citation.doi in cset:
+                citation = cset[citation.doi].because(citation.reasons)
+            cset[citation.doi] = citation
+        return list(cset.values())
 
     def fetch_bibtex(self):
         """Retrieve the bibtex of a citation from Crossref."""

--- a/stdpopsim/cli.py
+++ b/stdpopsim/cli.py
@@ -253,19 +253,15 @@ def write_citations(engine, model, contig):
     for the simulation engine, the model and the mutation/recombination rate
     information.
     """
-    printerr = functools.partial(print, file=sys.stderr)
-    printerr("If you use this simulation in published work, please cite:")
-    printerr(f"Simulation engine: {engine.name}")
-    for citation in engine.citations:
-        printerr(f"  {citation}")
+    print("If you use this simulation in published work, please cite:",
+          file=sys.stderr)
+    citations = engine.citations[:]
     if contig.genetic_map is not None:
-        printerr(f"Genetic map: {contig.genetic_map.name}")
-        for citation in contig.genetic_map.citations:
-            printerr(f"  {citation}")
-    if len(model.citations) > 0:
-        printerr(f"Simulation model: {model.name}")
-        for citation in model.citations:
-            printerr(f"  {citation}")
+        citations.extend(contig.genetic_map.citations)
+    citations.extend(model.citations)
+
+    for citation in stdpopsim.Citation.merge(citations):
+        citation.print(file=sys.stderr)
 
 
 def summarise_usage():

--- a/stdpopsim/engines.py
+++ b/stdpopsim/engines.py
@@ -101,7 +101,8 @@ class _MsprimeEngine(Engine):
             stdpopsim.Citation(
                 doi="https://doi.org/10.1371/journal.pcbi.1004842",
                 year="2016",
-                author="Kelleher et al."),
+                author="Kelleher et al.",
+                reasons={stdpopsim.CiteReason.ENGINE}),
             ]
 
     def simulate(self, demographic_model=None, contig=None, samples=None, seed=None,

--- a/stdpopsim/genomes.py
+++ b/stdpopsim/genomes.py
@@ -9,20 +9,29 @@ import attr
 logger = logging.getLogger(__name__)
 
 
-# TODO not clear whether it's worth using attrs here, since we only have one
-# instance variable that we supply. If we add more then we probably should
-# use attrs for consistency.
-
+@attr.s
 class Genome(object):
     """
     Class representing the genome for a species.
 
-    .. todo:: Define the facilities that this object provides.
+    :ivar chromosomes: A list of :class:`.Chromosome` objects.
+    :vartype chromosomes: list
+    :ivar mutation_rate_citations: A list of :class:`.Citation` objects
+        providing justification for the mutation rate estimate.
+    :vartype mutation_rate_citations: list
+    :ivar recombination_rate_citations: A list of :class:`.Citation` objects
+        providing justification for the recombination rate estimate.
+    :vartype recombination_rate_citations: list
+    :ivar length: The total length of the genome.
+    :vartype length: int
     """
-    def __init__(self, chromosomes):
-        self.chromosomes = chromosomes
-        self.length = 0
-        for chromosome in chromosomes:
+    chromosomes = attr.ib(factory=list)
+    mutation_rate_citations = attr.ib(factory=list, kw_only=True)
+    recombination_rate_citations = attr.ib(factory=list, kw_only=True)
+    length = attr.ib(default=0, init=False)
+
+    def __attrs_post_init__(self):
+        for chromosome in self.chromosomes:
             self.length += chromosome.length
 
     def __str__(self):

--- a/tests/test_citations.py
+++ b/tests/test_citations.py
@@ -59,3 +59,33 @@ class TestFetchBibtex(unittest.TestCase):
                                       author="Authors", year="2000")
         with self.assertRaises(urllib.error.HTTPError):
             citation.fetch_bibtex()
+
+
+class TestEverythingHappensForAReason(unittest.TestCase):
+    """
+    Test that citations have a reason.
+    """
+    def test_reasons_for_engine_citations(self):
+        for engine in stdpopsim.all_engines():
+            for citation in engine.citations:
+                self.assertGreater(
+                        len(citation.reasons), 0,
+                        msg=f"No reason given for '{citation.author}' citation "
+                            f"in engine {engine.id}")
+
+    def test_reason_for_genetic_map_citations(self):
+        for genetic_map in stdpopsim.all_genetic_maps():
+            for citation in genetic_map.citations:
+                self.assertGreater(
+                        len(citation.reasons), 0,
+                        msg=f"No reason given for '{citation.author}' citation "
+                            f"in genetic map "
+                            f"{genetic_map.species.id}/{genetic_map.name}")
+
+    def test_reason_for_model_citations(self):
+        for model in stdpopsim.all_demographic_models():
+            for citation in model.citations:
+                self.assertGreater(
+                        len(citation.reasons), 0,
+                        msg=f"No reason given for '{citation.author}' citation "
+                            f"in model {model.id}")


### PR DESCRIPTION
Modify citation writing as suggested in #316.

This overloads the addition operator of `Citation` to augment the citation with a reason. An explicit method call might make the code more obvious.